### PR TITLE
Endpoint fixes

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Provider/InMemoryProvider.cs
+++ b/Microsoft.SCIM.WebHostSample/Provider/InMemoryProvider.cs
@@ -6,42 +6,23 @@ namespace Microsoft.SCIM.WebHostSample.Provider
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.SCIM;
+    using Microsoft.SCIM.WebHostSample.Resources;
 
     public class InMemoryProvider : ProviderBase
     {
         private readonly ProviderBase groupProvider;
         private readonly ProviderBase userProvider;
 
+        private static readonly Lazy<IReadOnlyCollection<TypeScheme>> TypeSchema =
+            new Lazy<IReadOnlyCollection<TypeScheme>>(
+                () =>
+                    new TypeScheme[] { SampleTypeScheme.UserTypeSceme, SampleTypeScheme.GroupTypeSceme, SampleTypeScheme.EnterpriseUserTypeScheme });
+
         private static readonly Lazy<IReadOnlyCollection<Core2ResourceType>> Types =
             new Lazy<IReadOnlyCollection<Core2ResourceType>>(
                 () =>
-                    new Core2ResourceType[] { userResourceType, groupResourceType } );
+                    new Core2ResourceType[] { SampleResourceTypes.userResourceType, SampleResourceTypes.groupResourceType } );
 
-        private static Core2ResourceType userResourceType
-        {
-            get
-            {
-                Core2ResourceType userResource = new Core2ResourceType();
-                userResource.Identifier = "User";
-                userResource.Endpoint = new Uri("http://localhost:58464/Scim/Users");
-                userResource.Schema = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
-
-                return userResource;
-            }
-        }
-
-        private static Core2ResourceType groupResourceType
-        {
-            get
-            {
-                Core2ResourceType groupResource = new Core2ResourceType();
-                groupResource.Identifier = "Group";
-                groupResource.Endpoint = new Uri("http://localhost:58464/Scim/Groups");
-                groupResource.Schema = "urn:ietf:params:scim:schemas:core:2.0:Group";
-
-                return groupResource;
-            }
-        }
 
         public InMemoryProvider()
         {
@@ -54,6 +35,14 @@ namespace Microsoft.SCIM.WebHostSample.Provider
             get
             {
                 return InMemoryProvider.Types.Value;
+            }
+        }
+
+        public override IReadOnlyCollection<TypeScheme> Schema
+        {
+            get
+            {
+                return InMemoryProvider.TypeSchema.Value;
             }
         }
 

--- a/Microsoft.SCIM.WebHostSample/Provider/InMemoryProvider.cs
+++ b/Microsoft.SCIM.WebHostSample/Provider/InMemoryProvider.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.SCIM.WebHostSample.Provider
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.SCIM;
 
@@ -11,10 +12,49 @@ namespace Microsoft.SCIM.WebHostSample.Provider
         private readonly ProviderBase groupProvider;
         private readonly ProviderBase userProvider;
 
+        private static readonly Lazy<IReadOnlyCollection<Core2ResourceType>> Types =
+            new Lazy<IReadOnlyCollection<Core2ResourceType>>(
+                () =>
+                    new Core2ResourceType[] { userResourceType, groupResourceType } );
+
+        private static Core2ResourceType userResourceType
+        {
+            get
+            {
+                Core2ResourceType userResource = new Core2ResourceType();
+                userResource.Identifier = "User";
+                userResource.Endpoint = new Uri("http://localhost:58464/Scim/Users");
+                userResource.Schema = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+
+                return userResource;
+            }
+        }
+
+        private static Core2ResourceType groupResourceType
+        {
+            get
+            {
+                Core2ResourceType groupResource = new Core2ResourceType();
+                groupResource.Identifier = "Group";
+                groupResource.Endpoint = new Uri("http://localhost:58464/Scim/Groups");
+                groupResource.Schema = "urn:ietf:params:scim:schemas:core:2.0:Group";
+
+                return groupResource;
+            }
+        }
+
         public InMemoryProvider()
         {
             this.groupProvider = new InMemoryGroupProvider();
             this.userProvider = new InMemoryUserProvider();
+        }
+
+        public override IReadOnlyCollection<Core2ResourceType> ResourceTypes
+        {
+            get
+            {
+                return InMemoryProvider.Types.Value;
+            }
         }
 
         public override Task<Resource> CreateAsync(Resource resource, string correlationIdentifier)

--- a/Microsoft.SCIM.WebHostSample/Provider/InMemoryProvider.cs
+++ b/Microsoft.SCIM.WebHostSample/Provider/InMemoryProvider.cs
@@ -16,12 +16,20 @@ namespace Microsoft.SCIM.WebHostSample.Provider
         private static readonly Lazy<IReadOnlyCollection<TypeScheme>> TypeSchema =
             new Lazy<IReadOnlyCollection<TypeScheme>>(
                 () =>
-                    new TypeScheme[] { SampleTypeScheme.UserTypeSceme, SampleTypeScheme.GroupTypeSceme, SampleTypeScheme.EnterpriseUserTypeScheme });
+                    new TypeScheme[]
+                    { 
+                        SampleTypeScheme.UserTypeScheme,
+                        SampleTypeScheme.GroupTypeScheme, 
+                        SampleTypeScheme.EnterpriseUserTypeScheme,
+                        SampleTypeScheme.ResourceTypesTypeScheme,
+                        SampleTypeScheme.SchemaTypeScheme,
+                        SampleTypeScheme.ServiceProviderConfigTypeScheme
+                    });
 
         private static readonly Lazy<IReadOnlyCollection<Core2ResourceType>> Types =
             new Lazy<IReadOnlyCollection<Core2ResourceType>>(
                 () =>
-                    new Core2ResourceType[] { SampleResourceTypes.userResourceType, SampleResourceTypes.groupResourceType } );
+                    new Core2ResourceType[] { SampleResourceTypes.UserResourceType, SampleResourceTypes.GroupResourceType } );
 
 
         public InMemoryProvider()
@@ -30,22 +38,10 @@ namespace Microsoft.SCIM.WebHostSample.Provider
             this.userProvider = new InMemoryUserProvider();
         }
 
-        public override IReadOnlyCollection<Core2ResourceType> ResourceTypes
-        {
-            get
-            {
-                return InMemoryProvider.Types.Value;
-            }
-        }
-
-        public override IReadOnlyCollection<TypeScheme> Schema
-        {
-            get
-            {
-                return InMemoryProvider.TypeSchema.Value;
-            }
-        }
-
+        public override IReadOnlyCollection<Core2ResourceType> ResourceTypes => InMemoryProvider.Types.Value;
+       
+        public override IReadOnlyCollection<TypeScheme> Schema => InMemoryProvider.TypeSchema.Value;
+        
         public override Task<Resource> CreateAsync(Resource resource, string correlationIdentifier)
         {
             if (resource is Core2EnterpriseUser)

--- a/Microsoft.SCIM.WebHostSample/Provider/InMemoryStorage.cs
+++ b/Microsoft.SCIM.WebHostSample/Provider/InMemoryStorage.cs
@@ -22,12 +22,7 @@ namespace Microsoft.SCIM.WebHostSample.Provider
                                         () =>
                                             new InMemoryStorage());
 
-        public static InMemoryStorage Instance
-        {
-            get
-            {
-                return InMemoryStorage.InstanceValue.Value;
-            }
-        }
+        public static InMemoryStorage Instance => InMemoryStorage.InstanceValue.Value;
+        
     }
 }

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleAddressesAttribute.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleAddressesAttribute.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleAddressesAttribute
+    {
+        public static AttributeScheme FormattedAddressAttributeScheme
+        {
+            get
+            {
+                AttributeScheme formattedAddressScheme = new AttributeScheme("formatted", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionFormattedAddress
+                };
+                return formattedAddressScheme;
+
+            }
+        }
+        public static AttributeScheme StreetAddressAttributeScheme
+        {
+            get
+            {
+                AttributeScheme streetAddressScheme = new AttributeScheme("streetAddress", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionStreetAddress
+                };
+                return streetAddressScheme;
+
+            }
+        }
+
+        public static AttributeScheme CountryAddressAttributeScheme
+        {
+            get
+            {
+                AttributeScheme countryAddressScheme = new AttributeScheme("country", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAddressCountry
+                };
+                return countryAddressScheme;
+            }
+        }
+
+        public static AttributeScheme LocalityAddressAttributeScheme
+        {
+            get
+            {
+                AttributeScheme localityAddressScheme = new AttributeScheme("locality", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAddressLocality
+                };
+                return localityAddressScheme;
+            }
+        }
+
+        public static AttributeScheme PostalCodeAddressAttributeScheme
+        {
+            get
+            {
+                AttributeScheme postalCodeAddressScheme = new AttributeScheme("postalCode", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAddressPostalCode
+                };
+                return postalCodeAddressScheme;
+            }
+        }
+
+        public static AttributeScheme RegionAddressAttributeScheme
+        {
+            get
+            {
+                AttributeScheme regionAddressScheme = new AttributeScheme("region", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAddressRegion
+                };
+                return regionAddressScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleCommonAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleCommonAttributes.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleCommonAttributes
+    {
+        public static AttributeScheme IdentiFierAttributeScheme
+        {
+            get
+            {
+                AttributeScheme idScheme = new AttributeScheme("id", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionIdentifier
+                };
+                return idScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleConstants.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleConstants.cs
@@ -1,20 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
 
 namespace Microsoft.SCIM.WebHostSample.Resources
 {
     public class SampleConstants
     {
-        public const string Group = "Group";
-        public const string GroupSchema = "urn:ietf:params:scim:schemas:core:2.0:Group";
-        public const string User = "User";
+        public const string Core2SchemaPrefix = "urn:ietf:params:scim:schemas:core:2.0:";
         public const string UserAccount = "User Account";
-        public const string UserCore2Schema = "urn:ietf:params:scim:schemas:core:2.0:User";
+        public const string ServiceProviderConfig = "Service Provider Configuration";
         public const string UserEnterprise = "Enterprise User";
         public const string UserEnterpriseName = "EnterpriseUser";
         public const string UserEnterpriseSchema = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+        public const string DescriptionResourceTypeSchema = "Specifies the schema that describes a SCIM resource type";
         public const string DescriptionActive = "A Boolean value indicating the User's administrative status.";
         public const string DescriptionAddresses = "A physical mailing address for this User. Canonical type" +
             " values of \"work\", \"home\", and \"other\".  This attribute is a complex type with the following sub-attributes.";
@@ -52,8 +48,73 @@ namespace Microsoft.SCIM.WebHostSample.Resources
         public const string DescriptionUserType = "Used to identify the relationship between the organization and the user.  " +
             "Typical values used might be \"Contractor\", \"Employee\", \"Intern\", \"Temp\", \"External\", and \"Unknown\", " +
             "but any value may be used.";
-
-
-
+        public const string DescriptionValue = "The significant value for the attribute";
+        public const string DescriptionType = "A label indicating the attribute's function";
+        public const string DescriptionFormattedName = "The full name, including all middle " +
+            "names, titles, and suffixes as appropriate, formatted for display e.g., 'Ms. Barbara J Jensen, III').";
+        public const string DescriptionGivenName = "The given name of the User, or" +
+            " first name in most Western languages(e.g., 'Barbara' given the full name 'Ms. Barbara J Jensen, III').";
+        public const string DescriptionDisplay = "A human-readable name, primarily used for display purposes.READ-ONLY.";
+        public const string DescriptionPrimary = "A Boolean value indicating the 'primary' " + " or preferred attribute value for this attribute, " +
+            "The primary attribute value 'true' MUST appear no more than once.";
+        public const string DescriptionStreetAddress = "The full street address component, which may include house number, street name, P.O.box, and multi-line" +
+            "extended street address information.This attribute MAY contain newlines.";
+        public const string DescriptionFormattedAddress = "The full mailing address, formatted for display or use with a mailing label." +
+            " This attribute MAY contain newlines.";
+        public const string DescriptionFamilyName = "The family name of the User, or last name in most Western languages(e.g., 'Jensen' given the full " +
+            "name 'Ms. Barbara J Jensen, III').";
+        public const string DescriptionHonorificPrefix = "The honorific prefix(es) of the User, or title in most Western languages(e.g., 'Ms.' " +
+            "given the full name 'Ms. Barbara J Jensen, III').";
+        public const string DescriptionHonorificSuffix = "The honorific suffix(es) of the User, or suffix in most Western languages(e.g., 'III' " +
+            "given the full name 'Ms. Barbara J Jensen, III').";
+        public const string DescriptionNickName = "The casual way to address the user in real life, e.g., 'Bob' or 'Bobby' instead of 'Robert'. " +
+            "This attribute SHOULD NOT be used to represent a User's username (e.g., 'bjensen' or 'mpepperidge').";
+        public const string DescriptionTimeZone = "The User's time zone in the 'Olson' time zone database format, e.g., 'America/Los_Angeles'.";
+        public const string DescriptionPassword = "The User's cleartext password.  This attribute is intended to be used as a means to specify an initial " +
+            "password when creating a new User or to reset an existing User's password.";
+        public const string DescriptionIms = "Instant messaging addresses for the User.";
+        public const string DescriptionRoles = "A list of roles for the User that collectively represent who the User is, e.g., 'Student', 'Faculty'.";
+        public const string DescriptionIdentifier = "The server unique id of a SCIM resource";
+        public const string DescriptionResourceTypeName = "The resource type name.  When applicable,service providers MUST specify the name, e.g., 'User'.";
+        public const string DescriptionResourceTypeEndpoint = "The resource type's HTTP-addressable endpoint relative to the Base URL, e.g., '/Users'.";
+        public const string DescriptionResourceTypeSchemaAttribute = "The resource type's primary/base schema URI.";
+        public const string DescriptionScimSchema = "Specifies the schema that describes a SCIM schema";
+        public const string DescriptionSchemaName = "The schema's human-readable name.  When applicable, service providers MUST specify the name, e.g., 'User'.";
+        public const string DescriptionSchemaAttributes = "A complex attribute that includes the attributes of a schema.";
+        public const string DescriptionAttributeName = "The attribute's name.";
+        public const string DescriptionAttributeType = "The attribute's data type. Valid values include 'string', 'complex', 'boolean', 'decimal', 'integer', 'dateTime', 'reference'.";
+        public const string DescriptionAttributeMultiValued = "A Boolean value indicating an attribute's plurality.";
+        public const string DescriptionAttributeDescription = "A human-readable description of the attribute.";
+        public const string DescriptionAttributeRequired = "A boolean value indicating whether or not the attribute is required.";
+        public const string DescriptionAttributeCanonicalValues = "A collection of canonical values.  When applicable, service providers MUST specify the canonical types, e.g., 'work', 'home'.";
+        public const string DescriptionAttributeCaseExact = "A Boolean value indicating whether or not a string attribute is case sensitive.";
+        public const string DescriptionAttributeMutability = "Indicates whether or not an attribute is modifiable.";
+        public const string DescriptionAttributeReturned = "Indicates when an attribute is returned in a response(e.g., to a query).";
+        public const string DescriptionAttributeUniqueness = "Indicates how unique a value must be.";
+        public const string DescriptionAttributeReferenceTypes = "Used only with an attribute of type 'reference'.  Specifies a SCIM resourceType that a reference attribute MAY refer to, e.g., 'User'.";
+        public const string DescriptionAttributeSubAttributes = "Used to define the sub-attributes of a complex attribute.";
+        public const string DescriptionServiceProviderConfigSchema = "Schema for representing the service provider's configuration";
+        public const string DescriptionServiceProviderConfigDocumentationUri = "An HTTP-addressable URL pointing to the service provider's human-consumable help documentation.";
+        public const string DescriptionServiceProviderConfigPatch = "A complex type that specifies PATCH configuration options.";
+        public const string DescriptionServiceProviderConfigSupported = "A Boolean value specifying whether or not the operation is supported.";
+        public const string DescriptionServiceProviderConfigBulk = "A complex type that specifies bulk configuration options.";
+        public const string DescriptionServiceProviderConfigEtag = "A complex type that specifies ETag configuration options.REQUIRED.";
+        public const string DescriptionServiceProviderConfigBulkMaxOperations = "An integer value specifying the maximum number of operations.";
+        public const string DescriptionServiceProviderConfigBulkMaxPayloadSize = "An integer value specifying the maximum payload size in bytes.";
+        public const string DescriptionServiceProviderConfigFilter = "A complex type that specifies FILTER options.";
+        public const string DescriptionServiceProviderConfigFilterMaxResults = "An integer value specifying the maximum number of resources returned in a response.";
+        public const string DescriptionServiceProviderConfigChangePassword = "A complex type that specifies configuration options related to changing a password.";
+        public const string DescriptionServiceProviderConfigSort = "A complex type that specifies sort result options.";
+        public const string DescriptionServiceProviderAuthenticationSchemes = "A complex type that specifies supported authentication scheme properties.";
+        public const string DescriptionServiceProviderAuthenticationSchemesName = "The common authentication scheme name, e.g., HTTP Basic.";
+        public const string DescriptionServiceProviderAuthenticationSchemesDescription = "A description of the authentication scheme.";
+        public const string DescriptionServiceProviderAuthenticationSchemesSpecUri = "An HTTP-addressable URL pointing to the authentication scheme's specification.";
+        public const string DescriptionServiceProviderAuthenticationSchemesDocumentationUri = "An HTTP-addressable URL pointing to the authentication scheme's usage documentation.";
+        public const string DescriptionAddressCountry = "The country name component.";
+        public const string DescriptionAddressLocality = "The city or locality component.";
+        public const string DescriptionAddressPostalCode = "The country name component.";
+        public const string DescriptionAddressRegion = "The state or region component.";
+        public const string DescriptionAddressType = "A label indicating the attribute's function, e.g., 'work' or 'home'.";
+        public const  string SampleScimEndpoint = "http://localhost:5000/scim";
     }
 }

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleConstants.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleConstants.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public class SampleConstants
+    {
+        public const string Group = "Group";
+        public const string GroupSchema = "urn:ietf:params:scim:schemas:core:2.0:Group";
+        public const string User = "User";
+        public const string UserAccount = "User Account";
+        public const string UserCore2Schema = "urn:ietf:params:scim:schemas:core:2.0:User";
+        public const string UserEnterprise = "Enterprise User";
+        public const string UserEnterpriseName = "EnterpriseUser";
+        public const string UserEnterpriseSchema = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
+        public const string DescriptionActive = "A Boolean value indicating the User's administrative status.";
+        public const string DescriptionAddresses = "A physical mailing address for this User. Canonical type" +
+            " values of \"work\", \"home\", and \"other\".  This attribute is a complex type with the following sub-attributes.";
+        public const string DescriptionCostCenter = "Identifies the name of a cost center.";
+        public const string DescriptionDisplayName = "The name of the User, suitable for display to end-users.  " +
+            "The name SHOULD be the full name of the User being described, if known.";
+        public const string DescriptionDivision = "Identifies the name of a division.";
+        public const string Descriptiondepartment = "Identifies the name of a department.";
+        public const string DescriptionEmails = "Email addresses for the user.  The value SHOULD be canonicalized by " +
+            "the service provider, e.g., \"bjensen@example.com\" instead of \"bjensen@EXAMPLE.COM\". Canonical type values " +
+            "of \"work\", \"home\", and \"other\".";
+        public const string DescriptionEmployeeNumber = "Numeric or alphanumeric identifier assigned to a person, " +
+            "typically based on order of hire or association with an organization.";
+        public const string DescriptionGroupDisplayName = "A human-readable name for the Group. REQUIRED.";
+        public const string DescriptionLocale = "Used to indicate the User's default location for purposes of localizing" +
+            " items such as currency, date time format, or numerical representations.";
+        public const string DescriptionManager = "The User's manager.  A complex type that optionally allows " +
+            "service providers to represent organizational hierarchy by referencing the \"id\" attribute of another User.";
+        public const string DescriptionMemebers = "A list of members of the Group.";
+        public const string DescriptionName = "The components of the user's real name. Providers MAY return just " +
+            "the full name as a single string in the formatted sub-attribute, or they MAY return just the " +
+            "individual component attributes using the other sub-attributes, or they MAY return both.  " +
+            "If both variants are returned, they SHOULD be describing the same name, with the formatted name " +
+            "indicating how the component attributes should be combined.";
+        public const string DescriptionOrganization = "Identifies the name of an organization.";
+        public const string DescriptionPhoneNumbers = "Phone numbers for the User.  The value SHOULD be canonicalized" +
+            " by the service provider according to the format specified in RFC 3966, e.g., \"tel:+1-201-555-0123\". " +
+            "Canonical type values of \"work\", \"home\", \"mobile\", \"fax\", \"pager\", and \"other\".";
+        public const string DescriptionPreferredLanguage = "Indicates the User's preferred written or spoken language.  " +
+            "Generally used for selecting a localized user interface; e.g., \"en_US\" specifies the language English and country US.";
+        public const string DescriptionTitle = "The user's title, such as \"Vice President.\"";
+        public const string DescriptionUserName = "Unique identifier for the User, typically used by the user to " +
+            "directly authenticate to the service provider. Each User MUST include a non-empty userName value.  " +
+            "This identifier MUST be unique across the service provider's entire set of Users. REQUIRED.";
+        public const string DescriptionUserType = "Used to identify the relationship between the organization and the user.  " +
+            "Typical values used might be \"Contractor\", \"Employee\", \"Intern\", \"Temp\", \"External\", and \"Unknown\", " +
+            "but any value may be used.";
+
+
+
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleEnterpriseUserAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleEnterpriseUserAttributes.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleEnterpriseUserAttributes
+    {
+        public static AttributeScheme ManagerAttributeScheme
+        {
+            get
+            {
+                AttributeScheme managerScheme = new AttributeScheme("manager", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionManager
+                };
+                managerScheme.AddSubAttribute(SampleMultivaluedAttributes.ValueSubAttributeScheme);
+
+                return managerScheme;
+            }
+        }
+
+        public static AttributeScheme EmployeeNumberAttributeScheme
+        {
+            get
+            {
+                AttributeScheme employeeNumberScheme = new AttributeScheme("employeeNumber", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionEmployeeNumber
+                };
+                return employeeNumberScheme;
+            }
+        }
+
+        public static AttributeScheme CostcenterAttributeScheme
+        {
+            get
+            {
+                AttributeScheme costCenterScheme = new AttributeScheme("costCenter", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionCostCenter
+                };
+                return costCenterScheme;
+            }
+        }
+
+        public static AttributeScheme OrganizationAttributeScheme
+        {
+            get
+            {
+                AttributeScheme organizationScheme = new AttributeScheme("organization", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionOrganization
+                };
+                return organizationScheme;
+            }
+        }
+
+        public static AttributeScheme DivisionAttributeScheme
+        {
+            get
+            {
+                AttributeScheme divisionScheme = new AttributeScheme("division", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionDivision
+                };
+                return divisionScheme;
+            }
+        }
+
+        public static AttributeScheme DepartmentAttributeScheme
+        {
+            get
+            {
+                AttributeScheme departmentScheme = new AttributeScheme("department", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.Descriptiondepartment
+                };
+                return departmentScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleGroupAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleGroupAttributes.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleGroupAttributes
+    {
+        public static AttributeScheme GroupDisplayNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme groupDisplayScheme = new AttributeScheme("displayName", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionGroupDisplayName,
+                    Required = true,
+                    Uniqueness = Uniqueness.server
+                };
+
+                return groupDisplayScheme;
+            }
+        }
+
+        public static AttributeScheme MembersAttributeScheme
+        {
+            get
+            {
+                AttributeScheme membersScheme = new AttributeScheme("members", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionMemebers
+                };
+                membersScheme.AddSubAttribute(SampleMultivaluedAttributes.ValueSubAttributeScheme);
+                membersScheme.AddSubAttribute(SampleMultivaluedAttributes.TypeSubAttributeScheme);
+
+                return membersScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleMultivaluedAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleMultivaluedAttributes.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleMultivaluedAttributes
+    {
+        public static AttributeScheme ValueSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme valueScheme = new AttributeScheme("value", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionValue,
+                };
+                return valueScheme;
+            }
+        }
+
+        public static AttributeScheme TypeSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("type", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionType,
+                    Mutability = Mutability.immutable
+                };
+                typeScheme.AddCanonicalValues(Types.Group);
+                typeScheme.AddCanonicalValues(Types.User);
+
+                return typeScheme;
+            }
+        }
+
+        public static AttributeScheme DisplaySubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("display", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionDisplay
+                };
+                return typeScheme;
+            }
+        }
+
+        public static AttributeScheme Type2SubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("type", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionType
+                };
+                typeScheme.AddCanonicalValues("work");
+                typeScheme.AddCanonicalValues("home");
+                typeScheme.AddCanonicalValues("other");
+
+                return typeScheme;
+            }
+        }
+
+        public static AttributeScheme TypeAuthenticationSchemesAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("type", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionType,
+                    Required = true
+                };
+                typeScheme.AddCanonicalValues("oauth");
+                typeScheme.AddCanonicalValues("oauth2");
+                typeScheme.AddCanonicalValues("oauthbearertoken");
+                typeScheme.AddCanonicalValues("httpbasic");
+                typeScheme.AddCanonicalValues("httpdigest");
+
+                return typeScheme;
+            }
+        }
+
+        public static AttributeScheme TypeImsSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("type", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionType
+                };
+                typeScheme.AddCanonicalValues("aim");
+                typeScheme.AddCanonicalValues("gtalk");
+                typeScheme.AddCanonicalValues("icq");
+                typeScheme.AddCanonicalValues("xmpp");
+                typeScheme.AddCanonicalValues("msn");
+                typeScheme.AddCanonicalValues("skype");
+                typeScheme.AddCanonicalValues("qq");
+                typeScheme.AddCanonicalValues("yahoo");
+          
+                return typeScheme;
+            }
+        }
+
+        public static AttributeScheme TypeDefaultSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("type", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionType,
+                };
+                return typeScheme;
+            }
+        }
+
+        public static AttributeScheme PrimarySubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("primary", AttributeDataType.boolean, false)
+                {
+                    Description = SampleConstants.DescriptionPrimary
+                };
+                return typeScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleNameAttribute.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleNameAttribute.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleNameAttribute
+    {
+        public static AttributeScheme FormattedNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme formattedNameScheme = new AttributeScheme("formatted", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionFormattedName
+                };
+                return formattedNameScheme;
+            }
+        }
+
+        public static AttributeScheme GivenNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme givenNameScheme = new AttributeScheme("givenName", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionGivenName
+                };
+                return givenNameScheme;
+            }
+        }
+
+        public static AttributeScheme FamilyNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme familyNameScheme = new AttributeScheme("familyName", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionFamilyName
+                };
+                return familyNameScheme;
+            }
+        }
+
+        public static AttributeScheme HonorificPrefixAttributeScheme
+        {
+            get
+            {
+                AttributeScheme honorificPrefixScheme = new AttributeScheme("honorificPrefix", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionHonorificPrefix
+                };
+                return honorificPrefixScheme;
+            }
+        }
+
+        public static AttributeScheme HonorificSuffixAttributeScheme
+        {
+            get
+            {
+                AttributeScheme honorificSuffixScheme = new AttributeScheme("honorificSuffix", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionHonorificSuffix
+                };
+                return honorificSuffixScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypeAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypeAttributes.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleResourceTypeAttributes
+    {
+
+        public static AttributeScheme NameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionResourceTypeName
+                };
+                return nameScheme;
+            }
+        }
+
+        public static AttributeScheme EndpointAttributeScheme
+        {
+            get
+            {
+                AttributeScheme endpointScheme = new AttributeScheme("endpoint", AttributeDataType.reference, false)
+                {
+                    Description = SampleConstants.DescriptionResourceTypeEndpoint,
+                    Required = true,
+                    Mutability = Mutability.readOnly
+                };
+                endpointScheme.AddReferenceTypes("uri");
+
+                return endpointScheme;
+            }
+        }
+
+        public static AttributeScheme SchemaAttributeScheme
+        {
+            get
+            {
+                AttributeScheme schemaScheme = new AttributeScheme("schema", AttributeDataType.reference, false)
+                {
+                    Description = SampleConstants.DescriptionResourceTypeSchemaAttribute,
+                    Required = true,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+                schemaScheme.AddReferenceTypes("uri");
+
+                return schemaScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypes.cs
@@ -1,33 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
 
 namespace Microsoft.SCIM.WebHostSample.Resources
 {
+    using System;
+
     public class SampleResourceTypes
     {
-        public static Core2ResourceType userResourceType
+        public static Core2ResourceType UserResourceType
         {
             get
             {
-                Core2ResourceType userResource = new Core2ResourceType();
-                userResource.Identifier = SampleConstants.User;
-                userResource.Endpoint = new Uri("http://localhost:58464/Scim/Users");
-                userResource.Schema = SampleConstants.UserEnterpriseSchema;
+                Core2ResourceType userResource = new Core2ResourceType
+                {
+                    Identifier = Types.User,
+                    Endpoint = new Uri($"{SampleConstants.SampleScimEndpoint}/Users"),
+                    Schema = SampleConstants.UserEnterpriseSchema
+                };
 
                 return userResource;
             }
         }
 
-        public static Core2ResourceType groupResourceType
+        public static Core2ResourceType GroupResourceType
         {
             get
             {
-                Core2ResourceType groupResource = new Core2ResourceType();
-                groupResource.Identifier = SampleConstants.Group;
-                groupResource.Endpoint = new Uri("http://localhost:58464/Scim/Groups");
-                groupResource.Schema = SampleConstants.GroupSchema;
+                Core2ResourceType groupResource = new Core2ResourceType
+                {
+                    Identifier = Types.Group,
+                    Endpoint = new Uri($"{SampleConstants.SampleScimEndpoint}/Groups"),
+                    Schema = $"{SampleConstants.Core2SchemaPrefix}{Types.Group}"
+                };
 
                 return groupResource;
             }

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypes.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public class SampleResourceTypes
+    {
+        public static Core2ResourceType userResourceType
+        {
+            get
+            {
+                Core2ResourceType userResource = new Core2ResourceType();
+                userResource.Identifier = SampleConstants.User;
+                userResource.Endpoint = new Uri("http://localhost:58464/Scim/Users");
+                userResource.Schema = SampleConstants.UserEnterpriseSchema;
+
+                return userResource;
+            }
+        }
+
+        public static Core2ResourceType groupResourceType
+        {
+            get
+            {
+                Core2ResourceType groupResource = new Core2ResourceType();
+                groupResource.Identifier = SampleConstants.Group;
+                groupResource.Endpoint = new Uri("http://localhost:58464/Scim/Groups");
+                groupResource.Schema = SampleConstants.GroupSchema;
+
+                return groupResource;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleSchemaAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleSchemaAttributes.cs
@@ -1,0 +1,260 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public class SampleSchemaAttributes
+    {
+        public static AttributeScheme NameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionSchemaName,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return nameScheme;
+            }
+        }
+
+        public static AttributeScheme DescriptionAttributeScheme
+        {
+            get
+            {
+                AttributeScheme descriptionScheme = new AttributeScheme("description", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionSchemaName,
+                    Mutability = Mutability.readOnly,
+                };
+                return descriptionScheme;
+            }
+        }
+
+        public static AttributeScheme AttributesAttributeScheme
+        {
+            get
+            {
+                AttributeScheme attributesScheme = new AttributeScheme("attributes", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionSchemaAttributes,
+                    Mutability = Mutability.readOnly,
+                };
+                attributesScheme.AddSubAttribute(NameSubAttributeScheme);
+                attributesScheme.AddSubAttribute(TypeSubAttributeScheme);
+                attributesScheme.AddSubAttribute(MultiValuedSubAttributeScheme);
+                attributesScheme.AddSubAttribute(DescriptionSubAttributeScheme);
+                attributesScheme.AddSubAttribute(RequiredSubAttributeScheme);
+                attributesScheme.AddSubAttribute(CanonicalValuesSubAttributeScheme);
+                attributesScheme.AddSubAttribute(CaseExactSubAttributeScheme);
+                attributesScheme.AddSubAttribute(MutabilitySubAttributeScheme);
+                attributesScheme.AddSubAttribute(ReturnedSubAttributeScheme);
+                attributesScheme.AddSubAttribute(UniquenessSubAttributeScheme);
+                attributesScheme.AddSubAttribute(ReferenceTypesSubAttributeScheme);
+                attributesScheme.AddSubAttribute(SubAttributesSubAttributeScheme);
+
+                return attributesScheme;
+            }
+        }
+
+        public static AttributeScheme NameSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeName,
+                    Mutability = Mutability.readOnly,
+                    Required = true,
+                    CaseExact = true
+                };
+                return nameScheme;
+            }
+        }
+
+        public static AttributeScheme TypeSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme typeScheme = new AttributeScheme("type", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeType,
+                    Mutability = Mutability.readOnly,
+                    Required = true,
+                };
+                typeScheme.AddCanonicalValues("string");
+                typeScheme.AddCanonicalValues("complex");
+                typeScheme.AddCanonicalValues("boolean");
+                typeScheme.AddCanonicalValues("decimal");
+                typeScheme.AddCanonicalValues("integer");
+                typeScheme.AddCanonicalValues("dateTime");
+                typeScheme.AddCanonicalValues("reference");
+
+                return typeScheme;
+            }
+        }
+       public static AttributeScheme MultiValuedSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme multiValuedScheme = new AttributeScheme("multiValued", AttributeDataType.boolean, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeMultiValued,
+                    Mutability = Mutability.readOnly,
+                    Required = true,
+                };
+                return multiValuedScheme;
+            }
+       }
+
+        public static AttributeScheme DescriptionSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme descriptionScheme = new AttributeScheme("description", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeDescription,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+                return descriptionScheme;
+            }
+        }
+
+        public static AttributeScheme RequiredSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme requiredScheme = new AttributeScheme("required", AttributeDataType.boolean, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeRequired,
+                    Mutability = Mutability.readOnly,
+                };
+                return requiredScheme;
+            }
+        }
+
+        public static AttributeScheme CanonicalValuesSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme canonicalValuesScheme = new AttributeScheme("canonicalValues", AttributeDataType.@string, true)
+                {
+                    Description = SampleConstants.DescriptionAttributeCanonicalValues,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+                return canonicalValuesScheme;
+            }
+        }
+
+        public static AttributeScheme CaseExactSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme caseExactScheme = new AttributeScheme("caseExact", AttributeDataType.boolean, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeCaseExact,
+                    Mutability = Mutability.readOnly,
+                };
+                return caseExactScheme;
+            }
+        }
+
+        public static AttributeScheme MutabilitySubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme mutabilityScheme = new AttributeScheme("mutability", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeMutability,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+                mutabilityScheme.AddCanonicalValues("readOnly");
+                mutabilityScheme.AddCanonicalValues("readWrite");
+                mutabilityScheme.AddCanonicalValues("immutable");
+                mutabilityScheme.AddCanonicalValues("writeOnly");
+
+                return mutabilityScheme;
+            }
+        }
+
+        public static AttributeScheme ReturnedSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme returnedScheme = new AttributeScheme("returned", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeReturned,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+                returnedScheme.AddCanonicalValues("always");
+                returnedScheme.AddCanonicalValues("never");
+                returnedScheme.AddCanonicalValues("default");
+                returnedScheme.AddCanonicalValues("request");
+
+                return returnedScheme;
+            }
+        }
+
+        public static AttributeScheme UniquenessSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme uniquenessScheme = new AttributeScheme("uniqueness", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionAttributeUniqueness,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+                uniquenessScheme.AddCanonicalValues("none");
+                uniquenessScheme.AddCanonicalValues("server");
+                uniquenessScheme.AddCanonicalValues("global");
+
+                return uniquenessScheme;
+            }
+        }
+
+        public static AttributeScheme ReferenceTypesSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme referenceTypesScheme = new AttributeScheme("referenceTypes", AttributeDataType.@string, true)
+                {
+                    Description = SampleConstants.DescriptionAttributeReferenceTypes,
+                    Mutability = Mutability.readOnly,
+                    CaseExact = true
+                };
+
+                return referenceTypesScheme;
+            }
+        }
+
+        public static AttributeScheme SubAttributesSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme subAttributesScheme = new AttributeScheme("subAttributes", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionAttributeSubAttributes,
+                    Mutability = Mutability.readOnly,
+                };
+                subAttributesScheme.AddSubAttribute(NameSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(TypeSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(MultiValuedSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(DescriptionSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(RequiredSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(CanonicalValuesSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(CaseExactSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(MutabilitySubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(ReturnedSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(UniquenessSubAttributeScheme);
+                subAttributesScheme.AddSubAttribute(ReferenceTypesSubAttributeScheme);
+
+                return subAttributesScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleServiceProviderConfigAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleServiceProviderConfigAttributes.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleServiceProviderConfigAttributes
+    {
+        public static AttributeScheme DocumentationUriAttributeScheme
+        {
+            get
+            {
+                AttributeScheme documentationUriScheme = new AttributeScheme("documentationUri", AttributeDataType.reference, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigDocumentationUri,
+                    Mutability = Mutability.readOnly
+                };
+                documentationUriScheme.AddReferenceTypes("external");
+
+                return documentationUriScheme;
+            }
+        }
+
+        public static AttributeScheme PatchAttributeScheme
+        {
+            get
+            {
+                AttributeScheme patchScheme = new AttributeScheme("patch", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigPatch,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                patchScheme.AddSubAttribute(SupportedSubAttributeScheme);
+
+                return patchScheme;
+            }
+        }
+
+        public static AttributeScheme BulkAttributeScheme
+        {
+            get
+            {
+                AttributeScheme bulkScheme = new AttributeScheme("bulk", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigBulk,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                bulkScheme.AddSubAttribute(SupportedSubAttributeScheme);
+                bulkScheme.AddSubAttribute(MaxOperationsSubAttributeScheme);
+                bulkScheme.AddSubAttribute(MaxPayloadSizeSubAttributeScheme);
+
+                return bulkScheme;
+            }
+        }
+
+        public static AttributeScheme EtagAttributeScheme
+        {
+            get
+            {
+                AttributeScheme etagScheme = new AttributeScheme("etag", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigEtag,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                etagScheme.AddSubAttribute(SupportedSubAttributeScheme);
+
+                return etagScheme;
+            }
+        }
+
+        public static AttributeScheme FilterAttributeScheme
+        {
+            get
+            {
+                AttributeScheme filterScheme = new AttributeScheme("filter", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigFilter,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                filterScheme.AddSubAttribute(SupportedSubAttributeScheme);
+                filterScheme.AddSubAttribute(MaxResultsSubAttributeScheme);
+
+                return filterScheme;
+            }
+        }
+
+        public static AttributeScheme ChangePasswordAttributeScheme
+        {
+            get
+            {
+                AttributeScheme changePasswordScheme = new AttributeScheme("changePassword", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigChangePassword,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                changePasswordScheme.AddSubAttribute(SupportedSubAttributeScheme);
+
+                return changePasswordScheme;
+            }
+        }
+
+        public static AttributeScheme SortAttributeScheme
+        {
+            get
+            {
+                AttributeScheme sortScheme = new AttributeScheme("sort", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigSort,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                sortScheme.AddSubAttribute(SupportedSubAttributeScheme);
+
+                return sortScheme;
+            }
+        }
+
+        public static AttributeScheme AuthenticationSchemesAttributeScheme
+        {
+            get
+            {
+                AttributeScheme authenticationSchemesScheme = new AttributeScheme("authenticationSchemes", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderAuthenticationSchemes,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                authenticationSchemesScheme.AddSubAttribute(SampleMultivaluedAttributes.TypeAuthenticationSchemesAttributeScheme);
+                authenticationSchemesScheme.AddSubAttribute(NameSubAttributeScheme);
+                authenticationSchemesScheme.AddSubAttribute(DescriptionSubAttributeScheme);
+                authenticationSchemesScheme.AddSubAttribute(SpecUriSubAttributeScheme);
+                authenticationSchemesScheme.AddSubAttribute(DocumentationUriSubAttributeScheme);
+
+                return authenticationSchemesScheme;
+            }
+        }
+
+        public static AttributeScheme SupportedSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme supportedScheme = new AttributeScheme("supported", AttributeDataType.boolean, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigSupported,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return supportedScheme;
+            }
+        }
+
+        public static AttributeScheme MaxOperationsSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme maxOperationsScheme = new AttributeScheme("maxOperations", AttributeDataType.integer, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigBulkMaxOperations,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return maxOperationsScheme;
+            }
+        }
+
+        public static AttributeScheme MaxPayloadSizeSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme maxPayloadSizeScheme = new AttributeScheme("maxPayloadSize", AttributeDataType.integer, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigBulkMaxPayloadSize,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return maxPayloadSizeScheme;
+            }
+        }
+
+        public static AttributeScheme MaxResultsSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme maxResultsScheme = new AttributeScheme("maxResults", AttributeDataType.integer, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigFilterMaxResults,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return maxResultsScheme;
+            }
+        }
+
+        public static AttributeScheme NameSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderAuthenticationSchemesName,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return nameScheme;
+            }
+        }
+
+        public static AttributeScheme DescriptionSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme descriptionScheme = new AttributeScheme("description", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderAuthenticationSchemesDescription,
+                    Mutability = Mutability.readOnly,
+                    Required = true
+                };
+                return descriptionScheme;
+            }
+        }
+
+        public static AttributeScheme SpecUriSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme specUriScheme = new AttributeScheme("specUri", AttributeDataType.reference, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderAuthenticationSchemesSpecUri,
+                    Mutability = Mutability.readOnly,
+                };
+                specUriScheme.AddReferenceTypes("external");
+
+                return specUriScheme;
+            }
+        }
+
+        public static AttributeScheme DocumentationUriSubAttributeScheme
+        {
+            get
+            {
+                AttributeScheme documentationUriScheme = new AttributeScheme("documentationUri", AttributeDataType.reference, false)
+                {
+                    Description = SampleConstants.DescriptionServiceProviderAuthenticationSchemesDocumentationUri,
+                    Mutability = Mutability.readOnly,
+                };
+                documentationUriScheme.AddReferenceTypes("external");
+
+                return documentationUriScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleTypeScheme.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleTypeScheme.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleTypeScheme
+    {
+
+        public static TypeScheme UserTypeSceme
+        {
+            get
+            {
+                TypeScheme userType = new TypeScheme();
+                userType.Description = SampleConstants.UserAccount;
+                userType.Identifier = SampleConstants.UserCore2Schema;
+                userType.Name = SampleConstants.User;
+                userType.AddAttribute(UserNameAttributeScheme);
+                userType.AddAttribute(NameAttributeScheme);
+                userType.AddAttribute(DisplayNameAttributeScheme);
+                userType.AddAttribute(TittleAttributeScheme);
+                userType.AddAttribute(UserTypeAttributeScheme);
+                userType.AddAttribute(PreferredLanguageAttrbiuteScheme);
+                userType.AddAttribute(LocaleAttributeScheme);
+                userType.AddAttribute(ActiveAttributeScheme);
+                userType.AddAttribute(EmailsAttributeScheme);
+                userType.AddAttribute(PhoneNumbersAttributeScheme);
+                userType.AddAttribute(AddressesAttributeScheme);
+
+                return userType;
+            }
+        }
+
+        public static TypeScheme EnterpriseUserTypeScheme
+        {
+            get
+            {
+                TypeScheme enterpriseType = new TypeScheme();
+                enterpriseType.Description = SampleConstants.UserEnterprise;
+                enterpriseType.Identifier = SampleConstants.UserEnterpriseSchema;
+                enterpriseType.Name = SampleConstants.UserEnterpriseName;
+                enterpriseType.AddAttribute(ManagerAttributeScheme);
+                enterpriseType.AddAttribute(EmployeeNumberAttributeScheme);
+                enterpriseType.AddAttribute(CostcenterAttributeScheme);
+                enterpriseType.AddAttribute(OrganizationAttributeScheme);
+                enterpriseType.AddAttribute(DivisionAttributeScheme);
+                enterpriseType.AddAttribute(DepartmentAttributeScheme);
+
+                return enterpriseType;
+            }
+        }
+
+        public static TypeScheme GroupTypeSceme
+        {
+            get
+            {
+                TypeScheme groupType = new TypeScheme();
+                groupType.Description = SampleConstants.Group;
+                groupType.Identifier = SampleConstants.GroupSchema;
+                groupType.Name = SampleConstants.Group;
+                groupType.AddAttribute(GroupDisplayNameAttributeScheme);
+                groupType.AddAttribute(MembersAttributeScheme);
+
+                return groupType;
+            }
+        }
+
+        public static AttributeScheme GroupDisplayNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme groupDisplayScheme = new AttributeScheme("displayName", AttributeDataType.String, false);
+                groupDisplayScheme.Description = SampleConstants.DescriptionGroupDisplayName;
+                groupDisplayScheme.Required = true;
+                groupDisplayScheme.Uniqueness = Uniqueness.server;
+
+                return groupDisplayScheme;
+            }
+        }
+
+        public static AttributeScheme MembersAttributeScheme
+        {
+            get
+            {
+                AttributeScheme membersScheme = new AttributeScheme("members", AttributeDataType.Complex, true);
+                membersScheme.Description = SampleConstants.DescriptionMemebers;
+
+                return membersScheme;
+            }
+        }
+
+        public static AttributeScheme UserNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme userNameScheme = new AttributeScheme("userName", AttributeDataType.String, false);
+                userNameScheme.Description = SampleConstants.DescriptionUserName;
+                userNameScheme.Required = true;
+                userNameScheme.Uniqueness = Uniqueness.server;
+                return userNameScheme;
+            }
+        }
+
+        public static AttributeScheme NameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.Complex, false);
+                nameScheme.Description = SampleConstants.DescriptionName;
+                return nameScheme;
+            }
+        }
+
+        public static AttributeScheme DisplayNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme displayNameScheme = new AttributeScheme("displayName", AttributeDataType.String, false);
+                displayNameScheme.Description = SampleConstants.DescriptionDisplayName;
+                return displayNameScheme;
+            }
+        }
+
+        public static AttributeScheme TittleAttributeScheme
+        {
+            get
+            {
+                AttributeScheme titleScheme = new AttributeScheme("title", AttributeDataType.String, false);
+                titleScheme.Description = SampleConstants.DescriptionTitle;
+                return titleScheme;
+            }
+        }
+
+        public static AttributeScheme UserTypeAttributeScheme
+        {
+            get
+            {
+                AttributeScheme userTypeScheme = new AttributeScheme("userType", AttributeDataType.String, false);
+                userTypeScheme.Description = SampleConstants.DescriptionUserType;
+                return userTypeScheme;
+            }
+        }
+
+        public static AttributeScheme PreferredLanguageAttrbiuteScheme
+        {
+            get
+            {
+                AttributeScheme preferredLanguageScheme = new AttributeScheme("preferredLanguage", AttributeDataType.String, false);
+                preferredLanguageScheme.Description = SampleConstants.DescriptionPreferredLanguage;
+                return preferredLanguageScheme;
+            }
+        }
+
+        public static AttributeScheme LocaleAttributeScheme
+        {
+            get
+            {
+                AttributeScheme preferredLanguageScheme = new AttributeScheme("locale", AttributeDataType.String, false);
+                preferredLanguageScheme.Description = SampleConstants.DescriptionLocale;
+                return preferredLanguageScheme;
+            }
+        }
+
+        public static AttributeScheme ActiveAttributeScheme
+        {
+            get
+            {
+                AttributeScheme activeScheme = new AttributeScheme("active", AttributeDataType.Boolean, false);
+                activeScheme.Description = SampleConstants.DescriptionActive;
+                return activeScheme;
+            }
+        }
+
+        public static AttributeScheme EmailsAttributeScheme
+        {
+            get
+            {
+                AttributeScheme emailsScheme = new AttributeScheme("emails", AttributeDataType.Complex, true);
+                emailsScheme.Description = SampleConstants.DescriptionEmails;
+                return emailsScheme;
+            }
+        }
+
+        public static AttributeScheme PhoneNumbersAttributeScheme
+        {
+            get
+            {
+                AttributeScheme phoneNumbersScheme = new AttributeScheme("phoneNumbers", AttributeDataType.Complex, true);
+                phoneNumbersScheme.Description = SampleConstants.DescriptionPhoneNumbers;
+                return phoneNumbersScheme;
+            }
+        }
+
+        public static AttributeScheme AddressesAttributeScheme
+        {
+            get
+            {
+                AttributeScheme addressesScheme = new AttributeScheme("addresses", AttributeDataType.Complex, true);
+                addressesScheme.Description = SampleConstants.DescriptionAddresses;
+                return addressesScheme;
+            }
+        }
+
+        public static AttributeScheme ManagerAttributeScheme
+        {
+            get
+            {
+                AttributeScheme managerScheme = new AttributeScheme("manager", AttributeDataType.Complex, false);
+                managerScheme.Description = SampleConstants.DescriptionManager;
+                return managerScheme;
+            }
+        }
+
+        public static AttributeScheme EmployeeNumberAttributeScheme
+        {
+            get
+            {
+                AttributeScheme employeeNumberScheme = new AttributeScheme("employeeNumber", AttributeDataType.String, false);
+                employeeNumberScheme.Description = SampleConstants.DescriptionEmployeeNumber;
+                return employeeNumberScheme;
+            }
+        }
+
+        public static AttributeScheme CostcenterAttributeScheme
+        {
+            get
+            {
+                AttributeScheme costCenterScheme = new AttributeScheme("costCenter", AttributeDataType.String, false);
+                costCenterScheme.Description = SampleConstants.DescriptionCostCenter;
+                return costCenterScheme;
+            }
+        }
+
+        public static AttributeScheme OrganizationAttributeScheme
+        {
+            get
+            {
+                AttributeScheme organizationScheme = new AttributeScheme("organization", AttributeDataType.String, false);
+                organizationScheme.Description = SampleConstants.DescriptionOrganization;
+                return organizationScheme;
+            }
+        }
+
+        public static AttributeScheme DivisionAttributeScheme
+        {
+            get
+            {
+                AttributeScheme divisionScheme = new AttributeScheme("division", AttributeDataType.String, false);
+                divisionScheme.Description = SampleConstants.DescriptionDivision;
+                return divisionScheme;
+            }
+        }
+
+        public static AttributeScheme DepartmentAttributeScheme
+        {
+            get
+            {
+                AttributeScheme departmentScheme = new AttributeScheme("department", AttributeDataType.String, false);
+                departmentScheme.Description = SampleConstants.Descriptiondepartment;
+                return departmentScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleTypeScheme.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleTypeScheme.cs
@@ -1,32 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
 
 namespace Microsoft.SCIM.WebHostSample.Resources
 {
     public static class SampleTypeScheme
     {
 
-        public static TypeScheme UserTypeSceme
+        public static TypeScheme UserTypeScheme
         {
             get
             {
-                TypeScheme userType = new TypeScheme();
-                userType.Description = SampleConstants.UserAccount;
-                userType.Identifier = SampleConstants.UserCore2Schema;
-                userType.Name = SampleConstants.User;
-                userType.AddAttribute(UserNameAttributeScheme);
-                userType.AddAttribute(NameAttributeScheme);
-                userType.AddAttribute(DisplayNameAttributeScheme);
-                userType.AddAttribute(TittleAttributeScheme);
-                userType.AddAttribute(UserTypeAttributeScheme);
-                userType.AddAttribute(PreferredLanguageAttrbiuteScheme);
-                userType.AddAttribute(LocaleAttributeScheme);
-                userType.AddAttribute(ActiveAttributeScheme);
-                userType.AddAttribute(EmailsAttributeScheme);
-                userType.AddAttribute(PhoneNumbersAttributeScheme);
-                userType.AddAttribute(AddressesAttributeScheme);
+                TypeScheme userType = new TypeScheme
+                {
+                    Description = SampleConstants.UserAccount,
+                    Identifier = $"{SampleConstants.Core2SchemaPrefix}{Types.User}",
+                    Name = Types.User
+                };
+                userType.AddAttribute(SampleUserAttributes.UserNameAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.NameAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.DisplayNameAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.TitleAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.UserTypeAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.PreferredLanguageAttrbiuteScheme);
+                userType.AddAttribute(SampleUserAttributes.LocaleAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.ActiveAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.EmailsAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.PhoneNumbersAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.AddressesAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.NickNameAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.TimezoneAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.ImsAttributeScheme);
+                userType.AddAttribute(SampleUserAttributes.RolessAttributeScheme);
+
 
                 return userType;
             }
@@ -36,229 +40,97 @@ namespace Microsoft.SCIM.WebHostSample.Resources
         {
             get
             {
-                TypeScheme enterpriseType = new TypeScheme();
-                enterpriseType.Description = SampleConstants.UserEnterprise;
-                enterpriseType.Identifier = SampleConstants.UserEnterpriseSchema;
-                enterpriseType.Name = SampleConstants.UserEnterpriseName;
-                enterpriseType.AddAttribute(ManagerAttributeScheme);
-                enterpriseType.AddAttribute(EmployeeNumberAttributeScheme);
-                enterpriseType.AddAttribute(CostcenterAttributeScheme);
-                enterpriseType.AddAttribute(OrganizationAttributeScheme);
-                enterpriseType.AddAttribute(DivisionAttributeScheme);
-                enterpriseType.AddAttribute(DepartmentAttributeScheme);
+                TypeScheme enterpriseType = new TypeScheme
+                {
+                    Description = SampleConstants.UserEnterprise,
+                    Identifier = SampleConstants.UserEnterpriseSchema,
+                    Name = SampleConstants.UserEnterpriseName
+                };
+                enterpriseType.AddAttribute(SampleEnterpriseUserAttributes.ManagerAttributeScheme);
+                enterpriseType.AddAttribute(SampleEnterpriseUserAttributes.EmployeeNumberAttributeScheme);
+                enterpriseType.AddAttribute(SampleEnterpriseUserAttributes.CostcenterAttributeScheme);
+                enterpriseType.AddAttribute(SampleEnterpriseUserAttributes.OrganizationAttributeScheme);
+                enterpriseType.AddAttribute(SampleEnterpriseUserAttributes.DivisionAttributeScheme);
+                enterpriseType.AddAttribute(SampleEnterpriseUserAttributes.DepartmentAttributeScheme);
 
                 return enterpriseType;
             }
         }
 
-        public static TypeScheme GroupTypeSceme
+        public static TypeScheme GroupTypeScheme
         {
             get
             {
-                TypeScheme groupType = new TypeScheme();
-                groupType.Description = SampleConstants.Group;
-                groupType.Identifier = SampleConstants.GroupSchema;
-                groupType.Name = SampleConstants.Group;
-                groupType.AddAttribute(GroupDisplayNameAttributeScheme);
-                groupType.AddAttribute(MembersAttributeScheme);
-
+                TypeScheme groupType = new TypeScheme
+                {
+                    Description = Types.Group,
+                    Identifier = $"{SampleConstants.Core2SchemaPrefix}{Types.Group}",
+                    Name = Types.Group
+                };
+                groupType.AddAttribute(SampleGroupAttributes.GroupDisplayNameAttributeScheme);
+                groupType.AddAttribute(SampleGroupAttributes.MembersAttributeScheme);
                 return groupType;
             }
         }
 
-        public static AttributeScheme GroupDisplayNameAttributeScheme
+        public static TypeScheme ResourceTypesTypeScheme
         {
             get
             {
-                AttributeScheme groupDisplayScheme = new AttributeScheme("displayName", AttributeDataType.String, false);
-                groupDisplayScheme.Description = SampleConstants.DescriptionGroupDisplayName;
-                groupDisplayScheme.Required = true;
-                groupDisplayScheme.Uniqueness = Uniqueness.server;
+                TypeScheme resourceTypesType = new TypeScheme
+                {
+                    Description = SampleConstants.DescriptionResourceTypeSchema,
+                    Identifier = $"{SampleConstants.Core2SchemaPrefix}{Types.ResourceType}",
+                    Name = Types.ResourceType
+                };
+                resourceTypesType.AddAttribute(SampleCommonAttributes.IdentiFierAttributeScheme);
+                resourceTypesType.AddAttribute(SampleResourceTypeAttributes.NameAttributeScheme);
+                resourceTypesType.AddAttribute(SampleResourceTypeAttributes.EndpointAttributeScheme);
+                resourceTypesType.AddAttribute(SampleResourceTypeAttributes.SchemaAttributeScheme);
 
-                return groupDisplayScheme;
+                return resourceTypesType;
             }
         }
 
-        public static AttributeScheme MembersAttributeScheme
+        public static TypeScheme SchemaTypeScheme
         {
             get
             {
-                AttributeScheme membersScheme = new AttributeScheme("members", AttributeDataType.Complex, true);
-                membersScheme.Description = SampleConstants.DescriptionMemebers;
+                TypeScheme schemaType = new TypeScheme
+                {
+                    Description = SampleConstants.DescriptionScimSchema,
+                    Identifier = $"{SampleConstants.Core2SchemaPrefix}{Types.Schema}",
+                    Name = Types.Schema
+                };
+                schemaType.AddAttribute(SampleCommonAttributes.IdentiFierAttributeScheme);
+                schemaType.AddAttribute(SampleSchemaAttributes.NameAttributeScheme);
+                schemaType.AddAttribute(SampleSchemaAttributes.DescriptionAttributeScheme);
+                schemaType.AddAttribute(SampleSchemaAttributes.AttributesAttributeScheme);
 
-                return membersScheme;
+                return schemaType;
             }
         }
 
-        public static AttributeScheme UserNameAttributeScheme
+        public static TypeScheme ServiceProviderConfigTypeScheme
         {
             get
             {
-                AttributeScheme userNameScheme = new AttributeScheme("userName", AttributeDataType.String, false);
-                userNameScheme.Description = SampleConstants.DescriptionUserName;
-                userNameScheme.Required = true;
-                userNameScheme.Uniqueness = Uniqueness.server;
-                return userNameScheme;
-            }
-        }
+                TypeScheme serviceProviderConfigType = new TypeScheme
+                {
+                    Description = SampleConstants.DescriptionServiceProviderConfigSchema,
+                    Identifier = $"{SampleConstants.Core2SchemaPrefix}{Types.ServiceProviderConfiguration}",
+                    Name = SampleConstants.ServiceProviderConfig
+                };
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.DocumentationUriAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.PatchAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.BulkAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.FilterAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.ChangePasswordAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.SortAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.EtagAttributeScheme);
+                serviceProviderConfigType.AddAttribute(SampleServiceProviderConfigAttributes.AuthenticationSchemesAttributeScheme);
 
-        public static AttributeScheme NameAttributeScheme
-        {
-            get
-            {
-                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.Complex, false);
-                nameScheme.Description = SampleConstants.DescriptionName;
-                return nameScheme;
-            }
-        }
-
-        public static AttributeScheme DisplayNameAttributeScheme
-        {
-            get
-            {
-                AttributeScheme displayNameScheme = new AttributeScheme("displayName", AttributeDataType.String, false);
-                displayNameScheme.Description = SampleConstants.DescriptionDisplayName;
-                return displayNameScheme;
-            }
-        }
-
-        public static AttributeScheme TittleAttributeScheme
-        {
-            get
-            {
-                AttributeScheme titleScheme = new AttributeScheme("title", AttributeDataType.String, false);
-                titleScheme.Description = SampleConstants.DescriptionTitle;
-                return titleScheme;
-            }
-        }
-
-        public static AttributeScheme UserTypeAttributeScheme
-        {
-            get
-            {
-                AttributeScheme userTypeScheme = new AttributeScheme("userType", AttributeDataType.String, false);
-                userTypeScheme.Description = SampleConstants.DescriptionUserType;
-                return userTypeScheme;
-            }
-        }
-
-        public static AttributeScheme PreferredLanguageAttrbiuteScheme
-        {
-            get
-            {
-                AttributeScheme preferredLanguageScheme = new AttributeScheme("preferredLanguage", AttributeDataType.String, false);
-                preferredLanguageScheme.Description = SampleConstants.DescriptionPreferredLanguage;
-                return preferredLanguageScheme;
-            }
-        }
-
-        public static AttributeScheme LocaleAttributeScheme
-        {
-            get
-            {
-                AttributeScheme preferredLanguageScheme = new AttributeScheme("locale", AttributeDataType.String, false);
-                preferredLanguageScheme.Description = SampleConstants.DescriptionLocale;
-                return preferredLanguageScheme;
-            }
-        }
-
-        public static AttributeScheme ActiveAttributeScheme
-        {
-            get
-            {
-                AttributeScheme activeScheme = new AttributeScheme("active", AttributeDataType.Boolean, false);
-                activeScheme.Description = SampleConstants.DescriptionActive;
-                return activeScheme;
-            }
-        }
-
-        public static AttributeScheme EmailsAttributeScheme
-        {
-            get
-            {
-                AttributeScheme emailsScheme = new AttributeScheme("emails", AttributeDataType.Complex, true);
-                emailsScheme.Description = SampleConstants.DescriptionEmails;
-                return emailsScheme;
-            }
-        }
-
-        public static AttributeScheme PhoneNumbersAttributeScheme
-        {
-            get
-            {
-                AttributeScheme phoneNumbersScheme = new AttributeScheme("phoneNumbers", AttributeDataType.Complex, true);
-                phoneNumbersScheme.Description = SampleConstants.DescriptionPhoneNumbers;
-                return phoneNumbersScheme;
-            }
-        }
-
-        public static AttributeScheme AddressesAttributeScheme
-        {
-            get
-            {
-                AttributeScheme addressesScheme = new AttributeScheme("addresses", AttributeDataType.Complex, true);
-                addressesScheme.Description = SampleConstants.DescriptionAddresses;
-                return addressesScheme;
-            }
-        }
-
-        public static AttributeScheme ManagerAttributeScheme
-        {
-            get
-            {
-                AttributeScheme managerScheme = new AttributeScheme("manager", AttributeDataType.Complex, false);
-                managerScheme.Description = SampleConstants.DescriptionManager;
-                return managerScheme;
-            }
-        }
-
-        public static AttributeScheme EmployeeNumberAttributeScheme
-        {
-            get
-            {
-                AttributeScheme employeeNumberScheme = new AttributeScheme("employeeNumber", AttributeDataType.String, false);
-                employeeNumberScheme.Description = SampleConstants.DescriptionEmployeeNumber;
-                return employeeNumberScheme;
-            }
-        }
-
-        public static AttributeScheme CostcenterAttributeScheme
-        {
-            get
-            {
-                AttributeScheme costCenterScheme = new AttributeScheme("costCenter", AttributeDataType.String, false);
-                costCenterScheme.Description = SampleConstants.DescriptionCostCenter;
-                return costCenterScheme;
-            }
-        }
-
-        public static AttributeScheme OrganizationAttributeScheme
-        {
-            get
-            {
-                AttributeScheme organizationScheme = new AttributeScheme("organization", AttributeDataType.String, false);
-                organizationScheme.Description = SampleConstants.DescriptionOrganization;
-                return organizationScheme;
-            }
-        }
-
-        public static AttributeScheme DivisionAttributeScheme
-        {
-            get
-            {
-                AttributeScheme divisionScheme = new AttributeScheme("division", AttributeDataType.String, false);
-                divisionScheme.Description = SampleConstants.DescriptionDivision;
-                return divisionScheme;
-            }
-        }
-
-        public static AttributeScheme DepartmentAttributeScheme
-        {
-            get
-            {
-                AttributeScheme departmentScheme = new AttributeScheme("department", AttributeDataType.String, false);
-                departmentScheme.Description = SampleConstants.Descriptiondepartment;
-                return departmentScheme;
+                return serviceProviderConfigType;
             }
         }
     }

--- a/Microsoft.SCIM.WebHostSample/Resources/SampleUserAttributes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleUserAttributes.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft Corporation.// Licensed under the MIT license.
+
+namespace Microsoft.SCIM.WebHostSample.Resources
+{
+    public static class SampleUserAttributes
+    {
+        public static AttributeScheme UserNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme userNameScheme = new AttributeScheme("userName", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionUserName,
+                    Required = true,
+                    Uniqueness = Uniqueness.server
+                };
+                return userNameScheme;
+            }
+        }
+
+        public static AttributeScheme NameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nameScheme = new AttributeScheme("name", AttributeDataType.complex, false)
+                {
+                    Description = SampleConstants.DescriptionName
+                };
+                nameScheme.AddSubAttribute(SampleNameAttribute.FormattedNameAttributeScheme);
+                nameScheme.AddSubAttribute(SampleNameAttribute.GivenNameAttributeScheme);
+                nameScheme.AddSubAttribute(SampleNameAttribute.FamilyNameAttributeScheme);
+                nameScheme.AddSubAttribute(SampleNameAttribute.HonorificPrefixAttributeScheme);
+                nameScheme.AddSubAttribute(SampleNameAttribute.HonorificSuffixAttributeScheme);
+
+                return nameScheme;
+            }
+        }
+
+        public static AttributeScheme DisplayNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme displayNameScheme = new AttributeScheme("displayName", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionDisplayName
+                };
+                return displayNameScheme;
+            }
+        }
+
+        public static AttributeScheme NickNameAttributeScheme
+        {
+            get
+            {
+                AttributeScheme nickNameScheme = new AttributeScheme("nickName", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionNickName
+                };
+                return nickNameScheme;
+            }
+        }
+
+        public static AttributeScheme TitleAttributeScheme
+        {
+            get
+            {
+                AttributeScheme titleScheme = new AttributeScheme("title", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionTitle
+                };
+                return titleScheme;
+            }
+        }
+
+        public static AttributeScheme UserTypeAttributeScheme
+        {
+            get
+            {
+                AttributeScheme userTypeScheme = new AttributeScheme("userType", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionUserType
+                };
+                return userTypeScheme;
+            }
+        }
+
+        public static AttributeScheme PreferredLanguageAttrbiuteScheme
+        {
+            get
+            {
+                AttributeScheme preferredLanguageScheme = new AttributeScheme("preferredLanguage", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionPreferredLanguage
+                };
+                return preferredLanguageScheme;
+            }
+        }
+
+        public static AttributeScheme LocaleAttributeScheme
+        {
+            get
+            {
+                AttributeScheme localeScheme = new AttributeScheme("locale", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionLocale
+                };
+                return localeScheme;
+            }
+        }
+
+        public static AttributeScheme TimezoneAttributeScheme
+        {
+            get
+            {
+                AttributeScheme timezoneScheme = new AttributeScheme("timezone", AttributeDataType.@string, false)
+                {
+                    Description = SampleConstants.DescriptionTimeZone
+                };
+                return timezoneScheme;
+            }
+        }
+
+        public static AttributeScheme ActiveAttributeScheme
+        {
+            get
+            {
+                AttributeScheme activeScheme = new AttributeScheme("active", AttributeDataType.boolean, false)
+                {
+                    Description = SampleConstants.DescriptionActive
+                };
+                return activeScheme;
+            }
+        }
+
+        public static AttributeScheme EmailsAttributeScheme
+        {
+            get
+            {
+                AttributeScheme emailsScheme = new AttributeScheme("emails", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionEmails
+                };
+                emailsScheme.AddSubAttribute(SampleMultivaluedAttributes.ValueSubAttributeScheme);
+                emailsScheme.AddSubAttribute(SampleMultivaluedAttributes.Type2SubAttributeScheme);
+                emailsScheme.AddSubAttribute(SampleMultivaluedAttributes.PrimarySubAttributeScheme);
+
+                return emailsScheme;
+            }
+        }
+
+        public static AttributeScheme PhoneNumbersAttributeScheme
+        {
+            get
+            {
+                AttributeScheme phoneNumbersScheme = new AttributeScheme("phoneNumbers", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionPhoneNumbers
+                };
+                phoneNumbersScheme.AddSubAttribute(SampleMultivaluedAttributes.ValueSubAttributeScheme);
+                phoneNumbersScheme.AddSubAttribute(SampleMultivaluedAttributes.Type2SubAttributeScheme);
+                phoneNumbersScheme.AddSubAttribute(SampleMultivaluedAttributes.PrimarySubAttributeScheme);
+
+                return phoneNumbersScheme;
+            }
+        }
+
+        public static AttributeScheme AddressesAttributeScheme
+        {
+            get
+            {
+                AttributeScheme addressesScheme = new AttributeScheme("addresses", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionAddresses
+                };
+                addressesScheme.AddSubAttribute(SampleAddressesAttribute.FormattedAddressAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleAddressesAttribute.StreetAddressAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleMultivaluedAttributes.Type2SubAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleMultivaluedAttributes.PrimarySubAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleAddressesAttribute.CountryAddressAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleAddressesAttribute.LocalityAddressAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleAddressesAttribute.PostalCodeAddressAttributeScheme);
+                addressesScheme.AddSubAttribute(SampleAddressesAttribute.RegionAddressAttributeScheme);
+
+                return addressesScheme;
+            }
+        }
+
+        public static AttributeScheme ImsAttributeScheme
+        {
+            get
+            {
+                AttributeScheme imsScheme = new AttributeScheme("ims", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionIms
+                };
+                imsScheme.AddSubAttribute(SampleMultivaluedAttributes.ValueSubAttributeScheme);
+                imsScheme.AddSubAttribute(SampleMultivaluedAttributes.TypeImsSubAttributeScheme);
+                imsScheme.AddSubAttribute(SampleMultivaluedAttributes.PrimarySubAttributeScheme);
+
+                return imsScheme;
+            }
+        }
+
+        public static AttributeScheme RolessAttributeScheme
+        {
+            get
+            {
+                AttributeScheme rolesScheme = new AttributeScheme("roles", AttributeDataType.complex, true)
+                {
+                    Description = SampleConstants.DescriptionRoles
+                };
+                rolesScheme.AddSubAttribute(SampleMultivaluedAttributes.ValueSubAttributeScheme);
+                rolesScheme.AddSubAttribute(SampleMultivaluedAttributes.DisplaySubAttributeScheme);
+                rolesScheme.AddSubAttribute(SampleMultivaluedAttributes.TypeDefaultSubAttributeScheme);
+                rolesScheme.AddSubAttribute(SampleMultivaluedAttributes.PrimarySubAttributeScheme);
+
+                return rolesScheme;
+            }
+        }
+    }
+}

--- a/Microsoft.SCIM.WebHostSample/Startup.cs
+++ b/Microsoft.SCIM.WebHostSample/Startup.cs
@@ -15,6 +15,7 @@ namespace Microsoft.SCIM.WebHostSample
     using Microsoft.Extensions.Hosting;
     using Microsoft.IdentityModel.Tokens;
     using Microsoft.SCIM.WebHostSample.Provider;
+    using Newtonsoft.Json;
 
     public class Startup
     {
@@ -94,7 +95,10 @@ namespace Microsoft.SCIM.WebHostSample
                 });
             }
 
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options =>
+            {
+                options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+            });
             services.AddSingleton(typeof(IProvider), this.ProviderBehavior);
             services.AddSingleton(typeof(IMonitor), this.MonitoringBehavior);
         }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Filter.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Filter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.SCIM
             this.AttributePath = attributePath;
             this.FilterOperator = filterOperator;
             this.ComparisonValue = comparisonValue;
-            this.DataType = AttributeDataType.String;
+            this.DataType = AttributeDataType.@string;
         }
 
         public Filter(IFilter other)
@@ -236,12 +236,12 @@ namespace Microsoft.SCIM
             }
 
             string rightHandSide;
-            AttributeDataType effectiveDataType = this.DataType ?? AttributeDataType.String;
+            AttributeDataType effectiveDataType = this.DataType ?? AttributeDataType.@string;
             switch (effectiveDataType)
             {
-                case AttributeDataType.Boolean:
-                case AttributeDataType.Decimal:
-                case AttributeDataType.Integer:
+                case AttributeDataType.boolean:
+                case AttributeDataType.@decimal:
+                case AttributeDataType.integer:
                     rightHandSide = this.ComparisonValue;
                     break;
                 default:
@@ -375,32 +375,32 @@ namespace Microsoft.SCIM
 
             switch (dataType.Value)
             {
-                case AttributeDataType.Boolean:
+                case AttributeDataType.boolean:
                     if (!bool.TryParse(value, out bool _))
                     {
                         throw new InvalidOperationException(
                             SystemForCrossDomainIdentityManagementProtocolResources.ExceptionInvalidValue);
                     }
                     break;
-                case AttributeDataType.Decimal:
+                case AttributeDataType.@decimal:
                     if (!double.TryParse(value, out double _))
                     {
                         throw new InvalidOperationException(
                             SystemForCrossDomainIdentityManagementProtocolResources.ExceptionInvalidValue);
                     }
                     break;
-                case AttributeDataType.Integer:
+                case AttributeDataType.integer:
                     if (!long.TryParse(value, out long _))
                     {
                         throw new InvalidOperationException(
                             SystemForCrossDomainIdentityManagementProtocolResources.ExceptionInvalidValue);
                     }
                     break;
-                case AttributeDataType.Binary:
-                case AttributeDataType.Complex:
-                case AttributeDataType.DateTime:
-                case AttributeDataType.Reference:
-                case AttributeDataType.String:
+                case AttributeDataType.binary:
+                case AttributeDataType.complex:
+                case AttributeDataType.dateTime:
+                case AttributeDataType.reference:
+                case AttributeDataType.@string:
                     break;
                 default:
                     string unsupported = Enum.GetName(typeof(AttributeDataType), dataType.Value);

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/FilterExpression.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/FilterExpression.cs
@@ -791,23 +791,23 @@ namespace Microsoft.SCIM
 
                 if (this.Quoted)
                 {
-                    this.DataType = AttributeDataType.String;
+                    this.DataType = AttributeDataType.@string;
                 }
                 else if (bool.TryParse(this.Value, out bool _))
                 {
-                    this.DataType = AttributeDataType.Boolean;
+                    this.DataType = AttributeDataType.boolean;
                 }
                 else if (long.TryParse(this.Value, out long _))
                 {
-                    this.DataType = AttributeDataType.Integer;
+                    this.DataType = AttributeDataType.integer;
                 }
                 else if (double.TryParse(this.Value, out double _))
                 {
-                    this.DataType = AttributeDataType.Decimal;
+                    this.DataType = AttributeDataType.@decimal;
                 }
                 else
                 {
-                    this.DataType = AttributeDataType.String;
+                    this.DataType = AttributeDataType.@string;
                 }
             }
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/AttributeDataType.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/AttributeDataType.cs
@@ -7,13 +7,13 @@ namespace Microsoft.SCIM
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Enum of type names will contain type names")]
     public enum AttributeDataType
     {
-        String,
-        Boolean,
-        Decimal,
-        Integer,
-        DateTime,
-        Binary,
-        Reference,
-        Complex
+        @string,
+        boolean,
+        @decimal,
+        integer,
+        dateTime,
+        binary,
+        reference,
+        complex
     }
 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/AttributeNames.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/AttributeNames.cs
@@ -12,6 +12,7 @@ namespace Microsoft.SCIM
         public const string Attributes = "attributes";
         public const string AuthenticationSchemes = "authenticationSchemes";
         public const string Bulk = "bulk";
+        public const string CanonicalValues = "canonicalValues";
         public const string CaseExact = "caseExact";
         public const string ChangePassword = "changePassword";
         public const string ChangePollingInterval = AttributeNames.NotBefore;
@@ -72,6 +73,7 @@ namespace Microsoft.SCIM
         public const string Primary = "primary";
         public const string ProfileUrl = "profileUrl";
         public const string ProxyAddresses = "proxyAddresses";
+        public const string ReferenceTypes = "referenceTypes";
         public const string Region = "region";
         public const string Roles = "roles";
         public const string Required = "required";
@@ -83,6 +85,7 @@ namespace Microsoft.SCIM
         public const string Sort = "sort";
         public const string Specification = "specUrl";
         public const string StreetAddress = "streetAddress";
+        public const string SubAttributes = "subAttributes";
         public const string Supported = "supported";
         public const string TimeZone = "timezone";
         public const string Title = "title";

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Core2ResourceType.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Core2ResourceType.cs
@@ -8,19 +8,12 @@ namespace Microsoft.SCIM
     using System.Runtime.Serialization;
 
     [DataContract]
-    public sealed class Core2ResourceType : Schematized
+    public sealed class Core2ResourceType : Resource
     {
         private Uri endpoint;
 
         [DataMember(Name = AttributeNames.Endpoint)]
         private string endpointValue;
-
-        [DataMember(Name = AttributeNames.Identifier)]
-        public string Identifier
-        {
-            get;
-            set;
-        }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Serialized")]
         [DataMember(Name = AttributeNames.Name)]

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/SchemaIdentifiers.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/SchemaIdentifiers.cs
@@ -42,6 +42,11 @@ namespace Microsoft.SCIM
             SchemaIdentifiers.VersionSchemasCore2 +
             Types.User;
 
+        public const string Core2Schema =
+            SchemaIdentifiers.PrefixTypes2 +
+            SchemaIdentifiers.VersionSchemasCore2 +
+            Types.Schema;
+
         public const string PrefixExtension =
             SchemaIdentifiers.PrefixTypes2 +
             SchemaIdentifiers.Extension;

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Schematized.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Schematized.cs
@@ -25,6 +25,7 @@ namespace Microsoft.SCIM
             this.OnInitialized();
         }
 
+
         public virtual IReadOnlyCollection<string> Schemas
         {
             get

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/TypeScheme.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/TypeScheme.cs
@@ -10,27 +10,33 @@ namespace Microsoft.SCIM
     using System.Runtime.Serialization;
 
     [DataContract]
-    public sealed class TypeScheme : IJsonSerializable
+    public sealed class TypeScheme : Resource
     {
-        [DataMember(Name = AttributeNames.Attributes, Order = 0)]
         private List<AttributeScheme> attributes;
         private IReadOnlyCollection<AttributeScheme> attributesWrapper;
 
-        private IJsonSerializable serializer;
         private object thisLock;
 
         public TypeScheme()
         {
             this.OnInitialization();
             this.OnInitialized();
+            this.AddSchema(SchemaIdentifiers.Core2Schema);
+            this.Metadata =
+                new Core2Metadata()
+                {
+                    ResourceType = Types.Schema
+                };
         }
 
-        public IReadOnlyCollection<AttributeScheme> Attributes
+        [DataMember(Name = AttributeNames.Attributes, Order = 0)]
+        public IReadOnlyCollection<AttributeScheme> Attributes => this.attributesWrapper;
+
+        [DataMember(Name = AttributeNames.Name)]
+        public string Name
         {
-            get
-            {
-                return this.attributesWrapper;
-            }
+            get;
+            set;
         }
 
         [DataMember(Name = AttributeNames.Description)]
@@ -40,15 +46,8 @@ namespace Microsoft.SCIM
             set;
         }
 
-        [DataMember(Name = AttributeNames.Identifier)]
-        public string Identifier
-        {
-            get;
-            set;
-        }
-
-        [DataMember(Name = AttributeNames.Name)]
-        public string Name
+        [DataMember(Name = AttributeNames.Metadata)]
+        public Core2Metadata Metadata
         {
             get;
             set;
@@ -98,25 +97,12 @@ namespace Microsoft.SCIM
         private void OnInitialization()
         {
             this.thisLock = new object();
-            this.serializer = new JsonSerializer(this);
             this.attributes = new List<AttributeScheme>();
         }
 
         private void OnInitialized()
         {
             this.attributesWrapper = this.attributes.AsReadOnly();
-        }
-
-        public string Serialize()
-        {
-            string result = this.serializer.Serialize();
-            return result;
-        }
-
-        public Dictionary<string, object> ToJson()
-        {
-            Dictionary<string, object> result = this.serializer.ToJson();
-            return result;
-        }
+        }  
     }
 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Types.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Types.cs
@@ -10,5 +10,6 @@ namespace Microsoft.SCIM
         public const string ResourceType = "ResourceType";
         public const string ServiceProviderConfiguration = "ServiceProviderConfig";
         public const string User = "User";
+        public const string Schema = "Schema";
     }
 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ResourceTypesController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ResourceTypesController.cs
@@ -7,9 +7,11 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Web.Http;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
     [Route(ServiceConstants.RouteResourceTypes)]
+    [Authorize]
     [ApiController]
     public sealed class ResourceTypesController : ControllerTemplate
     {
@@ -18,7 +20,7 @@ namespace Microsoft.SCIM
         {
         }
 
-        public IEnumerable<Core2ResourceType> Get()
+        public QueryResponseBase Get()
         {
             string correlationIdentifier = null;
 
@@ -36,8 +38,15 @@ namespace Microsoft.SCIM
                     throw new HttpResponseException(HttpStatusCode.InternalServerError);
                 }
 
-                IEnumerable<Core2ResourceType> result = provider.ResourceTypes;
+                IReadOnlyCollection<Resource> resources = provider.ResourceTypes;
+                QueryResponseBase result = new QueryResponse(resources);
+
+                result.TotalResults =
+                    result.ItemsPerPage =
+                        resources.Count;
+                result.StartIndex = 1;
                 return result;
+
             }
             catch (ArgumentException argumentException)
             {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/SchemasController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/SchemasController.cs
@@ -7,9 +7,11 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Web.Http;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
     [Route(ServiceConstants.RouteSchemas)]
+    [Authorize]
     [ApiController]
     public sealed class SchemasController : ControllerTemplate
     {
@@ -18,7 +20,7 @@ namespace Microsoft.SCIM
         {
         }
 
-        public IEnumerable<TypeScheme> Get()
+        public QueryResponseBase Get()
         {
             string correlationIdentifier = null;
 
@@ -36,8 +38,15 @@ namespace Microsoft.SCIM
                     throw new HttpResponseException(HttpStatusCode.InternalServerError);
                 }
 
-                IEnumerable<TypeScheme> result = provider.Schema;
+                IReadOnlyCollection<Resource> resources = provider.Schema;
+                QueryResponseBase result = new QueryResponse(resources);
+                
+                result.TotalResults =
+                    result.ItemsPerPage =
+                        resources.Count;
+                result.StartIndex = 1;
                 return result;
+                
             }
             catch (ArgumentException argumentException)
             {

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ServiceProviderConfigurationController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/ServiceProviderConfigurationController.cs
@@ -6,9 +6,11 @@ namespace Microsoft.SCIM
     using System.Net;
     using System.Net.Http;
     using System.Web.Http;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
     [Route(ServiceConstants.RouteServiceConfiguration)]
+    [Authorize]
     [ApiController]
     public sealed class ServiceProviderConfigurationController : ControllerTemplate
     {


### PR DESCRIPTION
Problem: The provider base class does not return any values for resource types or schemas. Therefore running the sample as is with the InMemory provider returns empty arrays when calling the endpoints.
Solution: In order to increase the usefulness of the sample provider sample values have been added to the returned collection for Types and Schemas.
Validation: The included Postman tests for endpoint validation.