### PR TITLE
Patch request for phone fix

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Core2EnterpriseUserExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Core2EnterpriseUserExtensions.cs
@@ -929,8 +929,8 @@ namespace Microsoft.SCIM
                 return;
             }
 
-            PhoneNumber phoneNumber;
-            PhoneNumber phoneNumberExisting;
+            PhoneNumber phoneNumber = null;
+            PhoneNumber phoneNumberExisting = null;
             if (user.PhoneNumbers != null)
             {
                 phoneNumberExisting =
@@ -941,7 +941,8 @@ namespace Microsoft.SCIM
                             (PhoneNumber item) =>
                                 string.Equals(subAttribute.ComparisonValue, item.ItemType, StringComparison.Ordinal));
             }
-            else
+            
+            if(null == phoneNumber)
             {
                 phoneNumberExisting = null;
                 phoneNumber =


### PR DESCRIPTION
If we first add a "work" phone number all worked well.

Now howver we add a "mobile" number with a patch request. It would then see that we had any numbers at all since before, then it would try to look up a number of type "mobile" (however only number of type "work" exists) so it would return null.

A few lines further down it would assume phonNumber is a valid object which it's not.