### PR TITLE
Group members set to null fix

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
@@ -159,6 +159,11 @@ namespace Microsoft.SCIM
                                 IList<Member> buffer = new List<Member>();
                                 foreach (Member member in membersToAdd)
                                 {
+                                    if(group.Members == null)
+                                    {
+                                        group.Members = Enumerable.Empty<Member>();
+                                    }
+
                                     //O(n) with the number of group members, so for large groups this is not optimal
                                     if (!group.Members.Any((Member item) =>
                                             string.Equals(item.Value, member.Value, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
If Members property of a group is set to null it would fail on Apply with a patch operation to add a member.

Solution is a simple null check and assign an empty list.