### PR TITLE
avoid update email when trying to remove

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/ProtocolExtensions.cs
@@ -891,7 +891,7 @@ namespace Microsoft.SCIM
             string escapedIdentifier = Uri.EscapeDataString(resource.Identifier);
             string resultValue =
                 typeResource.ToString() +
-                ServiceConstants.SeparatorSegments + 
+                ServiceConstants.SeparatorSegments +
                 escapedIdentifier;
             result = new Uri(resultValue);
             return result;
@@ -1061,10 +1061,12 @@ namespace Microsoft.SCIM
             (
                     value != null
                 && OperationName.Remove == operation.Name
-                && string.Equals(value, electronicMailAddress.Value, StringComparison.OrdinalIgnoreCase)
             )
             {
-                value = null;
+                if (string.Equals(value, electronicMailAddress.Value, StringComparison.OrdinalIgnoreCase))
+                    value = null;
+                else // when the value not match, should skip remove anything, return the original emails
+                    return electronicMailAddresses;
             }
             electronicMailAddress.Value = value;
 


### PR DESCRIPTION
Currently, when removing an email in the patch request, if the value in the remove operation not match the current value, the value in the remove operation will be set the user.

e.g. Current User
`{..., "emails": [["type": "work", "primary": true, "value": "original@example.org"]]}, ...}`

After Apply Patch `{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"Remove","path":"emails[type eq \"work\"].value","value":"updated@example.org"}]}`

The user will be updated to `{..., "emails": [["type": "work", "primary": true, "value": "updated@example.org"]]}, ...}`