### PR TITLE
add support for schemaExtensions in ResourceType

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypes.cs
+++ b/Microsoft.SCIM.WebHostSample/Resources/SampleResourceTypes.cs
@@ -14,7 +14,12 @@ namespace Microsoft.SCIM.WebHostSample.Resources
                 {
                     Identifier = Types.User,
                     Endpoint = new Uri($"{SampleConstants.SampleScimEndpoint}/Users"),
-                    Schema = SampleConstants.UserEnterpriseSchema
+                    Schema = $"{SampleConstants.Core2SchemaPrefix}{Types.User}",
+                    SchemaExtensions = new Core2SchemaExtensions
+                    {
+                        Schema = SampleConstants.UserEnterpriseSchema,
+                        Required = false
+                    }
                 };
 
                 return userResource;

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/AttributeNames.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/AttributeNames.cs
@@ -80,6 +80,7 @@ namespace Microsoft.SCIM
         public const string ResourceType = "resourceType";
         public const string Returned = "returned";
         public const string Schema = "schema";
+        public const string SchemaExtensions = "schemaExtensions";
         public const string Schemas = "schemas";
         public const string SecurityEnabled = "securityEnabled";
         public const string Sort = "sort";

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Core2ResourceType.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Core2ResourceType.cs
@@ -57,6 +57,13 @@ namespace Microsoft.SCIM
             set;
         }
 
+        [DataMember(Name = AttributeNames.SchemaExtensions)]
+        public Core2SchemaExtensions SchemaExtensions
+        {
+            get;
+            set;
+        }
+
         private void InitializeEndpoint(string value)
         {
             if (string.IsNullOrWhiteSpace(value))

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Core2SchemaExtensions.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Schemas/Core2SchemaExtensions.cs
@@ -1,0 +1,27 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.SCIM
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [DataContract]
+    public sealed class Core2SchemaExtensions
+    {
+        [DataMember(Name = AttributeNames.Schema, Order = 0)]
+        public string Schema
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Name = AttributeNames.Required, Order = 1)]
+        public bool Required
+        {
+            get;
+            set;
+        }
+    }
+}


### PR DESCRIPTION
Update ResourceType to add the schemaExtensions attribute, according to the spec: [rfc7643#section-6](https://datatracker.ietf.org/doc/html/rfc7643#section-6)