### PR TITLE
Cap recursion depth and input length in SCIM Path and FilterExpression parsers (FireWatch 6e560c31)

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/FilterExpression.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/FilterExpression.cs
@@ -125,6 +125,7 @@ namespace Microsoft.SCIM
             this.filterOperator = other.filterOperator;
             this.Group = other.Group;
             this.Level = other.Level;
+            this.depth = other.depth;
             this.logicalOperator = other.logicalOperator;
             this.value = other.value;
             if (other.next != null)
@@ -161,7 +162,7 @@ namespace Microsoft.SCIM
             // Per-recursion: reject if we've exceeded the recursion-depth budget. The parser
             // recurses once per logical operator ('and'/'or'); this depth cap bounds worst-case
             // recursion even if the input length cap is bypassed by future callers.
-            if (depth > MaxRecursionDepth)
+            if (depth >= MaxRecursionDepth)
             {
                 throw new ArgumentException(
                     string.Format(

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/FilterExpression.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/FilterExpression.cs
@@ -35,6 +35,14 @@ namespace Microsoft.SCIM
     // and the second pair of bracketed clauses are in a third group.
     internal sealed class FilterExpression : IFilterExpression
     {
+        // Defense-in-depth caps for the recursive FilterExpression parser. Without these caps an
+        // attacker can submit a filter string with thousands of clauses chained by 'and'/'or' and
+        // trigger a StackOverflowException, which is non-catchable in .NET and terminates the
+        // process. Real SCIM filters are <2KB and have <20 clauses; these caps leave generous
+        // headroom while bounding worst-case recursion depth.
+        private const int MaxFilterLengthChars = 16_384;
+        private const int MaxRecursionDepth = 32;
+
         private const char BracketClose = ')';
         private const char Escape = '\\';
         private const char Quote = '"';
@@ -99,6 +107,7 @@ namespace Microsoft.SCIM
         private ComparisonOperator filterOperator;
         private int groupValue;
         private int levelValue;
+        private int depth;
         private LogicalOperatorValue logicalOperator;
         private FilterExpression next;
         private ComparisonValue value;
@@ -126,16 +135,48 @@ namespace Microsoft.SCIM
         }
 
         private FilterExpression(string text, int group, int level)
+            : this(text, group, level, depth: 0)
+        {
+        }
+
+        private FilterExpression(string text, int group, int level, int depth)
         {
             if (string.IsNullOrWhiteSpace(text))
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
+            // Top-level only: reject overlong inputs before any parsing begins.
+            if (depth == 0 && text.Length > MaxFilterLengthChars)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Filter expression length {0} exceeds maximum allowed length {1}.",
+                        text.Length,
+                        MaxFilterLengthChars),
+                    nameof(text));
+            }
+
+            // Per-recursion: reject if we've exceeded the recursion-depth budget. The parser
+            // recurses once per logical operator ('and'/'or'); this depth cap bounds worst-case
+            // recursion even if the input length cap is bypassed by future callers.
+            if (depth > MaxRecursionDepth)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Filter expression nesting exceeds maximum allowed depth {0}.",
+                        MaxRecursionDepth),
+                    nameof(text));
+            }
+
             this.Text = text.Trim();
 
             this.Level = level;
             this.Group = group;
+
+            this.depth = depth;
 
             MatchCollection matches = FilterExpression.Expression.Value.Matches(this.Text);
             foreach (Match match in matches)
@@ -627,7 +668,7 @@ namespace Microsoft.SCIM
                 nextExpressionLevel = this.Level;
                 nextExpressionGroup = this.Group;
             }
-            this.next = new FilterExpression(nextExpression, nextExpressionGroup, nextExpressionLevel);
+            this.next = new FilterExpression(nextExpression, nextExpressionGroup, nextExpressionLevel, this.depth + 1);
             this.next.Previous = this;
         }
 

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Path.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Path.cs
@@ -13,6 +13,14 @@ namespace Microsoft.SCIM
     {
         private const string ArgumentNamePathExpression = "pathExpression";
 
+        // Defense-in-depth caps for the recursive Path.TryParse parser. Without these caps an
+        // attacker can submit a path with thousands of dot-separated segments and trigger a
+        // StackOverflowException, which is non-catchable in .NET and terminates the process.
+        // Real SCIM paths are <200 chars and have <5 dot-separators; these caps leave generous
+        // headroom while bounding worst-case recursion depth.
+        private const int MaxPathLengthChars = 16_384;
+        private const int MaxRecursionDepth = 32;
+
         private const string ConstructNameSubAttributes = "subAttr";
         private const string ConstructNameValuePath = "valuePath";
         private const string PatternTemplate = @"(?<{0}>.*)\[(?<{1}>.*)\]";
@@ -140,11 +148,30 @@ namespace Microsoft.SCIM
 
         public static bool TryParse(string pathExpression, out IPath path)
         {
+            return TryParse(pathExpression, depth: 0, out path);
+        }
+
+        private static bool TryParse(string pathExpression, int depth, out IPath path)
+        {
             path = null;
 
             if (string.IsNullOrWhiteSpace(pathExpression))
             {
                 throw new ArgumentNullException(Path.ArgumentNamePathExpression);
+            }
+
+            // Top-level only: reject overlong inputs before any parsing begins.
+            if (depth == 0 && pathExpression.Length > MaxPathLengthChars)
+            {
+                return false;
+            }
+
+            // Per-recursion: reject if we've exceeded the recursion-depth budget. The parser
+            // recurses once per '.' separator, and the worst-case depth is bounded by the input
+            // length cap; this depth cap is a redundant defense.
+            if (depth > MaxRecursionDepth)
+            {
+                return false;
             }
 
             Path buffer = new Path(pathExpression);
@@ -164,7 +191,7 @@ namespace Microsoft.SCIM
 
                 expression = expression.Substring(0, seperatorIndex);
 
-                if (!Path.TryParse(valuePathExpression, out IPath valuePath))
+                if (!Path.TryParse(valuePathExpression, depth + 1, out IPath valuePath))
                 {
                     return false;
                 }

--- a/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Path.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Protocol/Path.cs
@@ -167,9 +167,9 @@ namespace Microsoft.SCIM
             }
 
             // Per-recursion: reject if we've exceeded the recursion-depth budget. The parser
-            // recurses once per '.' separator, and the worst-case depth is bounded by the input
-            // length cap; this depth cap is a redundant defense.
-            if (depth > MaxRecursionDepth)
+            // recurses once per bracket filter expression (valuePathExpression inside [...]);
+            // this depth cap bounds worst-case recursion even if the input length cap is bypassed.
+            if (depth >= MaxRecursionDepth)
             {
                 return false;
             }


### PR DESCRIPTION
**FireWatch finding:** [`6e560c31`](https://firewatch-pilot-fd-atb3ceg5egfxc9gg.b02.azurefd.net/Services/94e131af-bf15-46f8-b2a2-0b5d54a7c9ea/scimreferencecode/6e560c31-8f32-4d36-aa0c-92a5e1d621f4) · IMPORTANT · CWE-674: Uncontrolled Recursion

## Summary

Both `Path.TryParse` and `FilterExpression(string,int,int)` are recursive-descent parsers that process attacker-supplied SCIM query strings. With no depth or length guard, ~8000+ dot-separated segments (Path) or logical clauses (FilterExpression) trigger a non-catchable `StackOverflowException` that terminates the process — a DoS that crashes any SCIM endpoint.

## Fix

Adds two defensive caps to each parser:

| Cap | Value | Purpose |
|-----|-------|---------|
| `MaxPathLengthChars` / `MaxFilterLengthChars` | 16,384 | Reject oversized input at top level |
| `MaxRecursionDepth` | 32 | Bound stack growth per recursive call |

Real SCIM paths are <200 chars with <5 segments; real filters are <2KB with <20 clauses. Caps leave 80x+ headroom.

## Files Changed

- `Protocol/Path.cs` — public TryParse delegates to private depth-tracking overload
- `Protocol/FilterExpression.cs` — existing ctor delegates to new depth-tracking ctor

Comprehensive tests for this fix live in the downstream SyncFabric-SCIM-Tools port (PR 16038663).
