### PR TITLE
Add [Authorize] attribute to RootController to match sibling controllers (FireWatch 667635ff)

### DIFF
--- a/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/RootController.cs
+++ b/Microsoft.SystemForCrossDomainIdentityManagement/Service/Controllers/RootController.cs
@@ -3,7 +3,9 @@
 namespace Microsoft.SCIM
 {
     using System;
+    using Microsoft.AspNetCore.Authorization;
 
+    [Authorize]
     public sealed class RootController : ControllerTemplate<Resource>
     {
         public RootController(IProvider provider, IMonitor monitor)


### PR DESCRIPTION
**FireWatch finding:** [`667635ff`](https://firewatch-pilot-fd-atb3ceg5egfxc9gg.b02.azurefd.net/Services/94e131af-bf15-46f8-b2a2-0b5d54a7c9ea/scimreferencecode/667635ff-6b8d-4e7b-88d7-b5c2cce1a1c4) · IMPORTANT · CWE-862: Missing Authorization

## Summary

`RootController` exposes an endpoint at the service root without any authorization, while all 6 sibling resource controllers (Users, Groups, BulkRequest, ResourceTypes, Schemas, ServiceProviderConfiguration) carry `[Authorize]`. There is no `[AllowAnonymous]` marker, confirming this is an oversight rather than an intentional public endpoint.

## Fix

One-line change: add `[Authorize]` attribute to `RootController` to match every sibling controller.

## Impact

Low risk. Any consumer with ASP.NET Core authentication configured will now have the root endpoint automatically protected. Consumers without auth middleware configured see no behavior change.
