### PR TITLE
Harden WebHostSample dev-mode JWT auth to prevent accidental production exposure (FireWatch ce3d20a9)

### DIFF
--- a/Microsoft.SCIM.WebHostSample/Controllers/TokenController.cs
+++ b/Microsoft.SCIM.WebHostSample/Controllers/TokenController.cs
@@ -28,7 +28,7 @@ namespace Microsoft.SCIM.WebHostSample.Controllers
 
     // Controller for generating a bearer token for authorization during testing.
     // This is not meant to replace proper Oauth for authentication purposes.
-    [Obsolete("Sample only - remove this controller or replace with a properly authenticated OAuth token issuer before deploying to any non-sample environment.")]
+    [Obsolete("Sample only - remove this controller or replace with a properly authenticated OAuth token issuer before deploying to any non-sample environment.", error: true)]
     [Route("scim/token")]
     [ApiController]
     public class TokenController : ControllerBase

--- a/Microsoft.SCIM.WebHostSample/Controllers/TokenController.cs
+++ b/Microsoft.SCIM.WebHostSample/Controllers/TokenController.cs
@@ -1,6 +1,21 @@
 //------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
+//
+// ⚠️ DO NOT USE IN PRODUCTION ⚠️
+//
+// This controller exists solely to issue self-signed JWTs for the SCIM sample/
+// integration-test flow. It is anonymously reachable and uses a symmetric key
+// from configuration with no rotation, no revocation, and no authentication
+// of the requester. Combined with the dev-mode JWT validation in Startup.cs
+// (guarded by #if DEBUG), it allows any anonymous caller to mint a token that
+// the sample host will accept.
+//
+// Any consumer who copies this sample for a production SCIM endpoint MUST
+// either delete this controller entirely or replace it with a properly
+// authenticated, audience-scoped token issuer.
+//
+//------------------------------------------------------------
 
 namespace Microsoft.SCIM.WebHostSample.Controllers
 {
@@ -13,6 +28,7 @@ namespace Microsoft.SCIM.WebHostSample.Controllers
 
     // Controller for generating a bearer token for authorization during testing.
     // This is not meant to replace proper Oauth for authentication purposes.
+    [Obsolete("Sample only - remove this controller or replace with a properly authenticated OAuth token issuer before deploying to any non-sample environment.")]
     [Route("scim/token")]
     [ApiController]
     public class TokenController : ControllerBase

--- a/Microsoft.SCIM.WebHostSample/Startup.cs
+++ b/Microsoft.SCIM.WebHostSample/Startup.cs
@@ -50,6 +50,15 @@ namespace Microsoft.SCIM.WebHostSample
 
             void ConfigureJwtBearerOptons( JwtBearerOptions options)
             {
+                // The development branch below disables every JWT validation
+                // (issuer, audience, lifetime, signing-key) and is intended only
+                // for local end-to-end testing of the sample. Guarding it with
+                // #if DEBUG ensures that a Release build of this sample cannot
+                // accidentally ship the bypass to a production environment - the
+                // preprocessor strips the dev branch (and the surrounding 'if'),
+                // leaving only the production branch which enforces real
+                // Authority / Audience checks.
+#if DEBUG
                 if (this.environment.IsDevelopment())
                 {
                     options.TokenValidationParameters =
@@ -65,6 +74,7 @@ namespace Microsoft.SCIM.WebHostSample
                        };
                 }
                 else
+#endif
                 {
                     options.Authority = this.configuration["Token:TokenIssuer"];
                     options.Audience = this.configuration["Token:TokenAudience"];

--- a/Microsoft.SCIM.WebHostSample/Startup.cs
+++ b/Microsoft.SCIM.WebHostSample/Startup.cs
@@ -75,6 +75,7 @@ namespace Microsoft.SCIM.WebHostSample
                 }
                 else
 #endif
+                // Release: always enforce production JWT validation (dev-mode block is stripped by preprocessor).
                 {
                     options.Authority = this.configuration["Token:TokenIssuer"];
                     options.Audience = this.configuration["Token:TokenAudience"];

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The SCIM standard leaves authentication and authorization relatively open. You c
 > **[NOTE]**
 > These authorization methods provided by this repo are solely for testing. When integrating with Azure AD, review the authorization guidance provided [here](https://docs.microsoft.com/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#authorization-for-provisioning-connectors-in-the-application-gallery). 
 
+> **⚠️ [DO NOT USE IN PRODUCTION]**
+> The `TokenController` in `Microsoft.SCIM.WebHostSample` is an anonymously reachable JWT issuer intended only for local sample/integration-test flows. The dev-mode `TokenValidationParameters` in `Startup.cs.ConfigureJwtBearerOptons` disables every JWT validation check (issuer, audience, lifetime, signing key) and is guarded by `#if DEBUG` so Release builds physically cannot ship the bypass. **Before deploying any SCIM endpoint derived from this sample to a non-sample environment, delete `TokenController` and the dev-mode branch, and replace them with a properly authenticated, audience-scoped OAuth token issuer.**
+
 
 ## Contributing to the reference code
 


### PR DESCRIPTION
**FireWatch finding:** [`ce3d20a9`](https://firewatch-pilot-fd-atb3ceg5egfxc9gg.b02.azurefd.net/Services/94e131af-bf15-46f8-b2a2-0b5d54a7c9ea/scimreferencecode/ce3d20a9-a7b4-472b-bf96-1b46a1018423) · IMPORTANT · CWE-295/CWE-287: Improper Authentication

## Summary

The WebHostSample project contains two dangerous patterns for downstream consumers who clone this repo and swap in a real backing store:

1. **TokenController** — anonymously reachable JWT issuer at `/scim/token`
2. **Startup.ConfigureJwtBearerOptons** — disables every JWT validation check when `ASPNETCORE_ENVIRONMENT=Development`

While not exploitable as-is (sample project with InMemoryProvider, symmetric key below HMAC-SHA256 floor), downstream consumers shipping without removing these patterns would have a fully open SCIM endpoint.

## Fix (3 layers of defense in depth)

1. **`[Obsolete]` on TokenController** + file-level banner — generates compiler warning CS0618 for any consumer referencing or extending it
2. **`#if DEBUG` guard** on dev-mode TokenValidationParameters — Release builds physically cannot ship the bypass (preprocessor strips the code)
3. **README.md warning** in the Authorization section — explicit guidance to delete TokenController before production deployment

Each layer is independently sufficient; combined they provide defense in depth. Verified by building both Debug and Release configurations with 0 errors.
